### PR TITLE
feat: codegen pipeline — TS types → OpenAPI spec → Python client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+UPSTREAM_REPO = HelloAOLab/bible-api
+UPSTREAM_COMMIT = 1744dd35f460ec88526c063d5c8ecd819072567a
+SPEC_YAML = references/openapi.yaml
+SPEC_JSON = references/openapi.json
+CLIENT_DIR = scripts/generated_client
+
+.PHONY: fetch-upstream spec client all clean
+
+fetch-upstream:
+	@mkdir -p vendor
+	curl -sL "https://raw.githubusercontent.com/$(UPSTREAM_REPO)/$(UPSTREAM_COMMIT)/packages/helloao-tools/generation/api.ts" > vendor/api.ts
+	curl -sL "https://raw.githubusercontent.com/$(UPSTREAM_REPO)/$(UPSTREAM_COMMIT)/packages/helloao-tools/generation/common-types.ts" > vendor/common-types.ts
+	curl -sL "https://raw.githubusercontent.com/$(UPSTREAM_REPO)/$(UPSTREAM_COMMIT)/API-CHANGELOG.md" > vendor/API-CHANGELOG.md
+
+spec: vendor/api.ts vendor/common-types.ts
+	node scripts/generate_spec.js > $(SPEC_YAML)
+	node scripts/generate_spec.js --json > $(SPEC_JSON)
+
+client: $(SPEC_JSON)
+	python3 scripts/generate_client.py $(SPEC_JSON) $(CLIENT_DIR)
+
+all: spec client
+
+clean:
+	rm -rf $(CLIENT_DIR)/__pycache__

--- a/references/openapi.json
+++ b/references/openapi.json
@@ -1,0 +1,1577 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "helloao.org Bible API",
+    "version": "1.11.0",
+    "description": "Public, read-only JSON API serving Bible translations, books, and chapter content from helloao.org. No authentication required.",
+    "license": {
+      "name": "Various (per translation)",
+      "url": "https://helloao.org"
+    },
+    "x-api-source": "https://bible.helloao.org",
+    "x-api-changelog": "https://github.com/HelloAOLab/bible-api/blob/main/API-CHANGELOG.md"
+  },
+  "servers": [
+    {
+      "url": "https://bible.helloao.org",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/api/available_translations.json": {
+      "get": {
+        "operationId": "listTranslations",
+        "summary": "List all available translations",
+        "responses": {
+          "200": {
+            "description": "List of translations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "translations"
+                  ],
+                  "properties": {
+                    "translations": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Translation"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{translationId}/books.json": {
+      "get": {
+        "operationId": "listBooks",
+        "summary": "List books for a translation",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/translationId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Translation info and list of books",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "translation",
+                    "books"
+                  ],
+                  "properties": {
+                    "translation": {
+                      "$ref": "#/components/schemas/Translation"
+                    },
+                    "books": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/TranslationBook"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{translationId}/{bookId}/{chapter}.json": {
+      "get": {
+        "operationId": "getChapter",
+        "summary": "Get chapter content",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/translationId"
+          },
+          {
+            "$ref": "#/components/parameters/bookId"
+          },
+          {
+            "$ref": "#/components/parameters/chapter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chapter content with navigation links",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChapterResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{translationId}/complete.json": {
+      "get": {
+        "operationId": "getCompleteTranslation",
+        "summary": "Get complete translation download",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/translationId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Complete translation with all books and chapters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TranslationComplete"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/available_commentaries.json": {
+      "get": {
+        "operationId": "listCommentaries",
+        "summary": "List all available commentaries",
+        "responses": {
+          "200": {
+            "description": "List of commentaries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "commentaries"
+                  ],
+                  "properties": {
+                    "commentaries": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Commentary"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/c/{commentaryId}/books.json": {
+      "get": {
+        "operationId": "listCommentaryBooks",
+        "summary": "List books for a commentary",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/commentaryId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Commentary info and list of books",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "commentary",
+                    "books"
+                  ],
+                  "properties": {
+                    "commentary": {
+                      "$ref": "#/components/schemas/Commentary"
+                    },
+                    "books": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/CommentaryBook"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/c/{commentaryId}/{bookId}/{chapter}.json": {
+      "get": {
+        "operationId": "getCommentaryChapter",
+        "summary": "Get commentary chapter content",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/commentaryId"
+          },
+          {
+            "$ref": "#/components/parameters/bookId"
+          },
+          {
+            "$ref": "#/components/parameters/chapter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Commentary chapter content with navigation links",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentaryBookChapter"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/c/{commentaryId}/profiles.json": {
+      "get": {
+        "operationId": "listCommentaryProfiles",
+        "summary": "List profiles for a commentary",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/commentaryId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Commentary info and list of profiles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "commentary",
+                    "profiles"
+                  ],
+                  "properties": {
+                    "commentary": {
+                      "$ref": "#/components/schemas/Commentary"
+                    },
+                    "profiles": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/CommentaryProfileRef"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/c/{commentaryId}/profiles/{profileId}.json": {
+      "get": {
+        "operationId": "getCommentaryProfile",
+        "summary": "Get commentary profile content",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/commentaryId"
+          },
+          {
+            "$ref": "#/components/parameters/profileId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Commentary profile content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentaryProfileContent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/available_datasets.json": {
+      "get": {
+        "operationId": "listDatasets",
+        "summary": "List all available datasets",
+        "responses": {
+          "200": {
+            "description": "List of datasets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "datasets"
+                  ],
+                  "properties": {
+                    "datasets": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Dataset"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/d/{datasetId}/books.json": {
+      "get": {
+        "operationId": "listDatasetBooks",
+        "summary": "List books for a dataset",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/datasetId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dataset info and list of books",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "dataset",
+                    "books"
+                  ],
+                  "properties": {
+                    "dataset": {
+                      "$ref": "#/components/schemas/Dataset"
+                    },
+                    "books": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DatasetBook"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/d/{datasetId}/{bookId}/{chapter}.json": {
+      "get": {
+        "operationId": "getDatasetChapter",
+        "summary": "Get dataset chapter content (cross-references)",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/datasetId"
+          },
+          {
+            "$ref": "#/components/parameters/bookId"
+          },
+          {
+            "$ref": "#/components/parameters/chapter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dataset chapter content with cross-references",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetBookChapter"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "translationId": {
+        "name": "translationId",
+        "in": "path",
+        "required": true,
+        "description": "Translation identifier (e.g. BSB, KJV)",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "bookId": {
+        "name": "bookId",
+        "in": "path",
+        "required": true,
+        "description": "USFM book identifier (e.g. GEN, JHN, REV)",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "chapter": {
+        "name": "chapter",
+        "in": "path",
+        "required": true,
+        "description": "Chapter number",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "commentaryId": {
+        "name": "commentaryId",
+        "in": "path",
+        "required": true,
+        "description": "Commentary identifier",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "datasetId": {
+        "name": "datasetId",
+        "in": "path",
+        "required": true,
+        "description": "Dataset identifier",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "profileId": {
+        "name": "profileId",
+        "in": "path",
+        "required": true,
+        "description": "Profile identifier",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "schemas": {
+      "Translation": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "website",
+          "licenseUrl",
+          "englishName",
+          "language",
+          "textDirection",
+          "listOfBooksApiLink",
+          "availableFormats",
+          "numberOfBooks",
+          "totalNumberOfChapters",
+          "totalNumberOfVerses"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "website": {
+            "type": "string",
+            "description": "The english name of the translation. / englishName: string; /** The website for the translation."
+          },
+          "licenseUrl": {
+            "type": "string",
+            "description": "The english name of the translation. / englishName: string; /** The website for the translation. / website: string; /** The URL that the license for the translation can be found."
+          },
+          "licenseNotes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "licenseNotice": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The english name of the translation. / englishName: string; /** The website for the translation. / website: string; /** The URL that the license for the translation can be found. / licenseUrl: string; /** The notice that should be displayed when displaying content from the translation."
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "englishName": {
+            "type": "string",
+            "description": "The english name of the translation."
+          },
+          "language": {
+            "type": "string",
+            "description": "The english name of the translation. / englishName: string; /** The website for the translation. / website: string; /** The URL that the license for the translation can be found. / licenseUrl: string; /** The notice that should be displayed when displaying content from the translation. / licenseNotice?: string | null; /** The ISO 639 letter language tag that the translation is primarily in."
+          },
+          "textDirection": {
+            "type": "string",
+            "enum": [
+              "ltr",
+              "rtl"
+            ]
+          },
+          "listOfBooksApiLink": {
+            "type": "string"
+          },
+          "availableFormats": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "json",
+                "usfm"
+              ]
+            }
+          },
+          "numberOfBooks": {
+            "type": "integer"
+          },
+          "totalNumberOfChapters": {
+            "type": "integer"
+          },
+          "totalNumberOfVerses": {
+            "type": "integer"
+          },
+          "numberOfApocryphalBooks": {
+            "type": "integer"
+          },
+          "totalNumberOfApocryphalChapters": {
+            "type": "integer"
+          },
+          "totalNumberOfApocryphalVerses": {
+            "type": "integer"
+          },
+          "languageName": {
+            "type": "string"
+          },
+          "languageEnglishName": {
+            "type": "string"
+          },
+          "completeTranslationApiLink": {
+            "type": "string"
+          }
+        }
+      },
+      "TranslationBook": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "commonName",
+          "title",
+          "order",
+          "firstChapterNumber",
+          "firstChapterApiLink",
+          "lastChapterNumber",
+          "lastChapterApiLink",
+          "numberOfChapters",
+          "totalNumberOfVerses"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "commonName": {
+            "type": "string"
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "order": {
+            "type": "integer"
+          },
+          "isApocryphal": {
+            "type": "boolean"
+          },
+          "firstChapterNumber": {
+            "type": "integer"
+          },
+          "firstChapterApiLink": {
+            "type": "string"
+          },
+          "lastChapterNumber": {
+            "type": "integer"
+          },
+          "lastChapterApiLink": {
+            "type": "string"
+          },
+          "numberOfChapters": {
+            "type": "integer"
+          },
+          "totalNumberOfVerses": {
+            "type": "integer"
+          }
+        }
+      },
+      "ChapterResponse": {
+        "type": "object",
+        "required": [
+          "chapter",
+          "thisChapterAudioLinks",
+          "translation",
+          "book",
+          "thisChapterLink",
+          "nextChapterApiLink",
+          "nextChapterAudioLinks",
+          "previousChapterApiLink",
+          "previousChapterAudioLinks",
+          "numberOfVerses"
+        ],
+        "properties": {
+          "chapter": {
+            "$ref": "#/components/schemas/Chapter"
+          },
+          "thisChapterAudioLinks": {
+            "$ref": "#/components/schemas/AudioLinks"
+          },
+          "translation": {
+            "$ref": "#/components/schemas/Translation"
+          },
+          "book": {
+            "$ref": "#/components/schemas/TranslationBook"
+          },
+          "thisChapterLink": {
+            "type": "string"
+          },
+          "nextChapterApiLink": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "nextChapterAudioLinks": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AudioLinks"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "previousChapterApiLink": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "previousChapterAudioLinks": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AudioLinks"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "numberOfVerses": {
+            "type": "integer"
+          }
+        }
+      },
+      "TranslationComplete": {
+        "type": "object",
+        "required": [
+          "translation",
+          "books"
+        ],
+        "properties": {
+          "translation": {
+            "$ref": "#/components/schemas/Translation"
+          },
+          "books": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TranslationCompleteBook"
+            }
+          }
+        }
+      },
+      "TranslationCompleteBook": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "commonName",
+          "title",
+          "order",
+          "numberOfChapters",
+          "totalNumberOfVerses",
+          "chapters"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "commonName": {
+            "type": "string"
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "order": {
+            "type": "integer"
+          },
+          "numberOfChapters": {
+            "type": "integer"
+          },
+          "totalNumberOfVerses": {
+            "type": "integer"
+          },
+          "isApocryphal": {
+            "type": "boolean"
+          },
+          "chapters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TranslationBookChapter"
+            }
+          }
+        }
+      },
+      "Commentary": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "website",
+          "licenseUrl",
+          "englishName",
+          "language",
+          "textDirection",
+          "listOfBooksApiLink",
+          "listOfProfilesApiLink",
+          "availableFormats",
+          "numberOfBooks",
+          "totalNumberOfChapters",
+          "totalNumberOfVerses",
+          "totalNumberOfProfiles"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "website": {
+            "type": "string"
+          },
+          "licenseUrl": {
+            "type": "string"
+          },
+          "licenseNotes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "englishName": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string",
+            "description": "The ISO 639 letter language tag that the translation is primarily in."
+          },
+          "textDirection": {
+            "type": "string",
+            "enum": [
+              "ltr",
+              "rtl"
+            ]
+          },
+          "listOfBooksApiLink": {
+            "type": "string"
+          },
+          "listOfProfilesApiLink": {
+            "type": "string"
+          },
+          "availableFormats": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "json",
+                "usfm"
+              ]
+            }
+          },
+          "numberOfBooks": {
+            "type": "integer"
+          },
+          "totalNumberOfChapters": {
+            "type": "integer"
+          },
+          "totalNumberOfVerses": {
+            "type": "integer"
+          },
+          "totalNumberOfProfiles": {
+            "type": "integer"
+          },
+          "languageName": {
+            "type": "string"
+          },
+          "languageEnglishName": {
+            "type": "string"
+          }
+        }
+      },
+      "CommentaryBook": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "commonName",
+          "order",
+          "firstChapterNumber",
+          "firstChapterApiLink",
+          "lastChapterNumber",
+          "lastChapterApiLink",
+          "numberOfChapters",
+          "totalNumberOfVerses"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Defines an interface that contains information about a translation. / export interface Translation { /** The ID of the translation."
+          },
+          "name": {
+            "type": "string"
+          },
+          "commonName": {
+            "type": "string"
+          },
+          "introduction": {
+            "type": "string"
+          },
+          "introductionSummary": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "firstChapterNumber": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "firstChapterApiLink": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lastChapterNumber": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "lastChapterApiLink": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "numberOfChapters": {
+            "type": "integer"
+          },
+          "totalNumberOfVerses": {
+            "type": "integer",
+            "description": "The total number of chapters that are contained in this dataset. / totalNumberOfChapters: number; /** The total number of verses that are contained in this dataset."
+          }
+        }
+      },
+      "CommentaryBookChapter": {
+        "type": "object",
+        "required": [
+          "chapter",
+          "commentary",
+          "book",
+          "thisChapterLink",
+          "nextChapterApiLink",
+          "previousChapterApiLink",
+          "numberOfVerses"
+        ],
+        "properties": {
+          "chapter": {
+            "$ref": "#/components/schemas/CommentaryChapter"
+          },
+          "commentary": {
+            "$ref": "#/components/schemas/Commentary"
+          },
+          "book": {
+            "$ref": "#/components/schemas/CommentaryBook"
+          },
+          "thisChapterLink": {
+            "type": "string"
+          },
+          "nextChapterApiLink": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "previousChapterApiLink": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "numberOfVerses": {
+            "type": "integer"
+          }
+        }
+      },
+      "CommentaryProfileRef": {
+        "type": "object",
+        "required": [
+          "id",
+          "subject",
+          "thisProfileLink"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "reference": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "book": {
+                    "type": "string"
+                  },
+                  "chapter": {
+                    "type": "integer"
+                  },
+                  "verse": {
+                    "type": "integer"
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "thisProfileLink": {
+            "type": "string"
+          },
+          "referenceChapterLink": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "CommentaryProfileContent": {
+        "type": "object",
+        "required": [
+          "commentary",
+          "profile",
+          "content"
+        ],
+        "properties": {
+          "commentary": {
+            "$ref": "#/components/schemas/Commentary"
+          },
+          "profile": {
+            "$ref": "#/components/schemas/CommentaryProfileRef"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Dataset": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "website",
+          "licenseUrl",
+          "englishName",
+          "language",
+          "textDirection",
+          "listOfBooksApiLink",
+          "availableFormats",
+          "numberOfBooks",
+          "totalNumberOfChapters",
+          "totalNumberOfVerses",
+          "totalNumberOfReferences"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The metadata for a translation that is input into the generator. / export interface InputTranslationMetadata extends MetadataBase { /** The ID of the translation."
+          },
+          "name": {
+            "type": "string"
+          },
+          "website": {
+            "type": "string"
+          },
+          "licenseUrl": {
+            "type": "string"
+          },
+          "licenseNotes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "englishName": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "textDirection": {
+            "type": "string",
+            "enum": [
+              "ltr",
+              "rtl"
+            ]
+          },
+          "listOfBooksApiLink": {
+            "type": "string"
+          },
+          "availableFormats": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "json"
+              ]
+            }
+          },
+          "numberOfBooks": {
+            "type": "integer"
+          },
+          "totalNumberOfChapters": {
+            "type": "integer"
+          },
+          "totalNumberOfVerses": {
+            "type": "integer"
+          },
+          "totalNumberOfReferences": {
+            "type": "integer"
+          },
+          "languageName": {
+            "type": "string"
+          },
+          "languageEnglishName": {
+            "type": "string"
+          }
+        }
+      },
+      "DatasetBook": {
+        "type": "object",
+        "required": [
+          "id",
+          "order",
+          "firstChapterNumber",
+          "firstChapterApiLink",
+          "lastChapterNumber",
+          "lastChapterApiLink",
+          "numberOfChapters",
+          "totalNumberOfVerses",
+          "totalNumberOfReferences"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "firstChapterNumber": {
+            "type": "integer"
+          },
+          "firstChapterApiLink": {
+            "type": "string"
+          },
+          "lastChapterNumber": {
+            "type": "integer"
+          },
+          "lastChapterApiLink": {
+            "type": "string"
+          },
+          "numberOfChapters": {
+            "type": "integer"
+          },
+          "totalNumberOfVerses": {
+            "type": "integer"
+          },
+          "totalNumberOfReferences": {
+            "type": "integer",
+            "description": "The total number of references that are contained in this dataset."
+          }
+        }
+      },
+      "DatasetBookChapter": {
+        "type": "object",
+        "required": [
+          "chapter",
+          "dataset",
+          "book",
+          "thisChapterLink",
+          "nextChapterApiLink",
+          "previousChapterApiLink",
+          "numberOfVerses",
+          "numberOfReferences"
+        ],
+        "properties": {
+          "chapter": {
+            "$ref": "#/components/schemas/DatasetChapterData"
+          },
+          "dataset": {
+            "$ref": "#/components/schemas/Dataset"
+          },
+          "book": {
+            "$ref": "#/components/schemas/DatasetBook"
+          },
+          "thisChapterLink": {
+            "type": "string"
+          },
+          "nextChapterApiLink": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "previousChapterApiLink": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "numberOfVerses": {
+            "type": "integer"
+          },
+          "numberOfReferences": {
+            "type": "integer"
+          }
+        }
+      },
+      "Chapter": {
+        "type": "object",
+        "required": [
+          "number",
+          "content",
+          "footnotes"
+        ],
+        "properties": {
+          "number": {
+            "type": "integer"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChapterContent"
+            }
+          },
+          "footnotes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChapterFootnote"
+            }
+          }
+        }
+      },
+      "CommentaryChapter": {
+        "type": "object",
+        "required": [
+          "number",
+          "content"
+        ],
+        "properties": {
+          "number": {
+            "type": "integer"
+          },
+          "introduction": {
+            "type": "string"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChapterVerse"
+            }
+          }
+        }
+      },
+      "ChapterContent": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChapterHeading"
+          },
+          {
+            "$ref": "#/components/schemas/ChapterLineBreak"
+          },
+          {
+            "$ref": "#/components/schemas/ChapterVerse"
+          },
+          {
+            "$ref": "#/components/schemas/ChapterHebrewSubtitle"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "verse": "#/components/schemas/ChapterVerse",
+            "heading": "#/components/schemas/ChapterHeading",
+            "line_break": "#/components/schemas/ChapterLineBreak",
+            "hebrew_subtitle": "#/components/schemas/ChapterHebrewSubtitle"
+          }
+        }
+      },
+      "ChapterHeading": {
+        "type": "object",
+        "required": [
+          "type",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "heading"
+            ]
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Heading text segments; concatenate with a space"
+          }
+        }
+      },
+      "ChapterLineBreak": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "line_break"
+            ]
+          }
+        }
+      },
+      "ChapterVerse": {
+        "type": "object",
+        "required": [
+          "type",
+          "number",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "verse"
+            ]
+          },
+          "number": {
+            "type": "integer"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VerseContentItem"
+            }
+          }
+        }
+      },
+      "ChapterHebrewSubtitle": {
+        "type": "object",
+        "required": [
+          "type",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "hebrew_subtitle"
+            ]
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/FormattedText"
+                },
+                {
+                  "$ref": "#/components/schemas/VerseFootnoteReference"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "FormattedText": {
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "poem": {
+            "type": "integer"
+          },
+          "wordsOfJesus": {
+            "type": "boolean"
+          }
+        }
+      },
+      "InlineHeading": {
+        "type": "object",
+        "required": [
+          "heading"
+        ],
+        "properties": {
+          "heading": {
+            "type": "string"
+          }
+        }
+      },
+      "InlineLineBreak": {
+        "type": "object",
+        "required": [
+          "lineBreak"
+        ],
+        "properties": {
+          "lineBreak": {
+            "type": "boolean",
+            "const": true
+          }
+        }
+      },
+      "VerseFootnoteReference": {
+        "type": "object",
+        "required": [
+          "noteId"
+        ],
+        "properties": {
+          "noteId": {
+            "type": "integer"
+          }
+        }
+      },
+      "ChapterFootnote": {
+        "type": "object",
+        "required": [
+          "noteId",
+          "text",
+          "caller"
+        ],
+        "properties": {
+          "noteId": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          },
+          "reference": {
+            "type": "object",
+            "properties": {
+              "chapter": {
+                "type": "integer"
+              },
+              "verse": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "chapter",
+              "verse"
+            ]
+          },
+          "caller": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "+"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        }
+      },
+      "AudioLinks": {
+        "type": "object",
+        "description": "Map of reader name to audio file URL",
+        "additionalProperties": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "DatasetChapterData": {
+        "type": "object",
+        "required": [
+          "number",
+          "content"
+        ],
+        "properties": {
+          "number": {
+            "type": "integer"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatasetChapterVerseContent"
+            }
+          }
+        }
+      },
+      "DatasetChapterVerseContent": {
+        "type": "object",
+        "required": [
+          "verse",
+          "references"
+        ],
+        "properties": {
+          "verse": {
+            "type": "integer"
+          },
+          "references": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CrossReference"
+            }
+          }
+        }
+      },
+      "CrossReference": {
+        "type": "object",
+        "required": [
+          "book",
+          "chapter",
+          "verse",
+          "score"
+        ],
+        "properties": {
+          "book": {
+            "type": "string",
+            "description": "USFM book identifier"
+          },
+          "chapter": {
+            "type": "integer",
+            "description": "Chapter number"
+          },
+          "verse": {
+            "type": "integer",
+            "description": "Verse number"
+          },
+          "score": {
+            "type": "number",
+            "description": "Relevance score"
+          }
+        }
+      },
+      "CommentaryProfile": {
+        "type": "object",
+        "required": [
+          "id",
+          "subject",
+          "reference"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "reference": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "book",
+                  "chapter",
+                  "verse"
+                ],
+                "properties": {
+                  "book": {
+                    "type": "string"
+                  },
+                  "chapter": {
+                    "type": "integer"
+                  },
+                  "verse": {
+                    "type": "integer"
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "VerseContentItem": {
+        "description": "A single element within verse content",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/FormattedText"
+          },
+          {
+            "$ref": "#/components/schemas/VerseFootnoteReference"
+          },
+          {
+            "$ref": "#/components/schemas/InlineHeading"
+          },
+          {
+            "$ref": "#/components/schemas/InlineLineBreak"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/references/openapi.yaml
+++ b/references/openapi.yaml
@@ -1,20 +1,16 @@
-openapi: 3.1.0
+openapi: '3.1.0'
 info:
   title: helloao.org Bible API
-  version: 1.11.0
-  description: >
-    Public, read-only JSON API serving Bible translations, books, and chapter
-    content from helloao.org. No authentication required.
+  version: '1.11.0'
+  description: Public, read-only JSON API serving Bible translations, books, and chapter content from helloao.org. No authentication required.
   license:
     name: Various (per translation)
-    url: https://helloao.org
-  x-api-source: https://bible.helloao.org
-  x-api-changelog: https://github.com/HelloAOLab/bible-api/blob/main/API-CHANGELOG.md
-
+    url: 'https://helloao.org'
+  x-api-source: 'https://bible.helloao.org'
+  x-api-changelog: 'https://github.com/HelloAOLab/bible-api/blob/main/API-CHANGELOG.md'
 servers:
-  - url: https://bible.helloao.org
+  - url: 'https://bible.helloao.org'
     description: Production
-
 paths:
   /api/available_translations.json:
     get:
@@ -33,8 +29,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Translation'
-
-  /api/{translationId}/books.json:
+  '/api/{translationId}/books.json':
     get:
       operationId: listBooks
       summary: List books for a translation
@@ -55,8 +50,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/TranslationBook'
-
-  /api/{translationId}/{bookId}/{chapter}.json:
+  '/api/{translationId}/{bookId}/{chapter}.json':
     get:
       operationId: getChapter
       summary: Get chapter content
@@ -71,7 +65,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ChapterResponse'
-
+  '/api/{translationId}/complete.json':
+    get:
+      operationId: getCompleteTranslation
+      summary: Get complete translation download
+      parameters:
+        - $ref: '#/components/parameters/translationId'
+      responses:
+        '200':
+          description: Complete translation with all books and chapters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranslationComplete'
   /api/available_commentaries.json:
     get:
       operationId: listCommentaries
@@ -89,8 +95,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Commentary'
-
-  /api/c/{commentaryId}/books.json:
+  '/api/c/{commentaryId}/books.json':
     get:
       operationId: listCommentaryBooks
       summary: List books for a commentary
@@ -111,8 +116,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/CommentaryBook'
-
-  /api/c/{commentaryId}/{bookId}/{chapter}.json:
+  '/api/c/{commentaryId}/{bookId}/{chapter}.json':
     get:
       operationId: getCommentaryChapter
       summary: Get commentary chapter content
@@ -127,7 +131,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CommentaryBookChapter'
-
+  '/api/c/{commentaryId}/profiles.json':
+    get:
+      operationId: listCommentaryProfiles
+      summary: List profiles for a commentary
+      parameters:
+        - $ref: '#/components/parameters/commentaryId'
+      responses:
+        '200':
+          description: Commentary info and list of profiles
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [commentary, profiles]
+                properties:
+                  commentary:
+                    $ref: '#/components/schemas/Commentary'
+                  profiles:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CommentaryProfileRef'
+  '/api/c/{commentaryId}/profiles/{profileId}.json':
+    get:
+      operationId: getCommentaryProfile
+      summary: Get commentary profile content
+      parameters:
+        - $ref: '#/components/parameters/commentaryId'
+        - $ref: '#/components/parameters/profileId'
+      responses:
+        '200':
+          description: Commentary profile content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommentaryProfileContent'
   /api/available_datasets.json:
     get:
       operationId: listDatasets
@@ -145,8 +183,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Dataset'
-
-  /api/d/{datasetId}/books.json:
+  '/api/d/{datasetId}/books.json':
     get:
       operationId: listDatasetBooks
       summary: List books for a dataset
@@ -167,8 +204,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/DatasetBook'
-
-  /api/d/{datasetId}/{bookId}/{chapter}.json:
+  '/api/d/{datasetId}/{bookId}/{chapter}.json':
     get:
       operationId: getDatasetChapter
       summary: Get dataset chapter content (cross-references)
@@ -183,7 +219,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DatasetBookChapter'
-
 components:
   parameters:
     translationId:
@@ -222,7 +257,13 @@ components:
       description: Dataset identifier
       schema:
         type: string
-
+    profileId:
+      name: profileId
+      in: path
+      required: true
+      description: Profile identifier
+      schema:
+        type: string
   schemas:
     Translation:
       type: object
@@ -234,213 +275,484 @@ components:
         - englishName
         - language
         - textDirection
-        - sha256
-        - availableFormats
         - listOfBooksApiLink
+        - availableFormats
         - numberOfBooks
         - totalNumberOfChapters
         - totalNumberOfVerses
-        - languageName
-        - languageEnglishName
       properties:
         id:
           type: string
-          description: Unique translation identifier
-          examples: ['BSB']
         name:
           type: string
-          description: Full name of the translation
-          examples: ['Berean Standard Bible']
         website:
           type: string
-          format: uri
-          description: Website for the translation
+          description: 'The english name of the translation. / englishName: string; /** The website for the translation.'
         licenseUrl:
           type: string
-          format: uri
-          description: URL for the translation license
+          description: 'The english name of the translation. / englishName: string; /** The website for the translation. / website: string; /** The URL that the license for the translation can be found.'
+        licenseNotes:
+          type: [string, 'null']
+        licenseNotice:
+          type: [string, 'null']
+          description: 'The english name of the translation. / englishName: string; /** The website for the translation. / website: string; /** The URL that the license for the translation can be found. / licenseUrl: string; /** The notice that should be displayed when displaying content from the translation.'
         shortName:
           type: string
-          description: Short name / abbreviation
-          examples: ['BSB']
         englishName:
           type: string
-          description: English name of the translation
+          description: The english name of the translation.
         language:
           type: string
-          description: ISO 639 3-letter language code
-          examples: ['eng']
+          description: 'The english name of the translation. / englishName: string; /** The website for the translation. / website: string; /** The URL that the license for the translation can be found. / licenseUrl: string; /** The notice that should be displayed when displaying content from the translation. / licenseNotice?: string | null; /** The ISO 639 letter language tag that the translation is primarily in.'
         textDirection:
           type: string
           enum: [ltr, rtl]
-          description: Text writing direction
-        sha256:
+        listOfBooksApiLink:
           type: string
-          description: SHA-256 hash of the translation content
         availableFormats:
           type: array
           items:
             type: string
-          description: Available download formats
-          examples: [['json']]
-        listOfBooksApiLink:
-          type: string
-          description: API path to the books list
-          examples: ['/api/BSB/books.json']
-        completeTranslationApiLink:
-          type: string
-          description: API path to the complete translation
-          examples: ['/api/BSB/complete.json']
+            enum: [json, usfm]
         numberOfBooks:
           type: integer
-          description: Total number of books in the translation
         totalNumberOfChapters:
           type: integer
-          description: Total number of chapters across all books
         totalNumberOfVerses:
           type: integer
-          description: Total number of verses across all books
+        numberOfApocryphalBooks:
+          type: integer
+        totalNumberOfApocryphalChapters:
+          type: integer
+        totalNumberOfApocryphalVerses:
+          type: integer
         languageName:
           type: string
-          description: Language name in the native language
-          examples: ['English']
         languageEnglishName:
           type: string
-          description: Language name in English
-          examples: ['English']
-
+        completeTranslationApiLink:
+          type: string
     TranslationBook:
       type: object
       required:
         - id
-        - translationId
         - name
         - commonName
+        - title
         - order
-        - numberOfChapters
-        - sha256
         - firstChapterNumber
         - firstChapterApiLink
         - lastChapterNumber
         - lastChapterApiLink
+        - numberOfChapters
         - totalNumberOfVerses
       properties:
         id:
           type: string
-          description: USFM book identifier
-          examples: ['GEN']
-        translationId:
-          type: string
-          description: Parent translation identifier
-          examples: ['BSB']
         name:
           type: string
-          description: Book name as provided by the translation
-          examples: ['Genesis']
         commonName:
           type: string
-          description: Common English name for the book
-          examples: ['Genesis']
         title:
-          type: ['string', 'null']
-          description: Descriptive title for the book, if provided
-          examples: ['Genesis']
+          type: [string, 'null']
         order:
           type: integer
-          description: Numerical order of the book in the translation
-          examples: [1]
-        numberOfChapters:
-          type: integer
-          description: Number of chapters in the book
-        sha256:
-          type: string
-          description: SHA-256 hash of the book content
+        isApocryphal:
+          type: boolean
         firstChapterNumber:
           type: integer
-          description: Number of the first chapter
         firstChapterApiLink:
           type: string
-          description: API path to the first chapter
-          examples: ['/api/BSB/GEN/1.json']
         lastChapterNumber:
           type: integer
-          description: Number of the last chapter
         lastChapterApiLink:
           type: string
-          description: API path to the last chapter
-          examples: ['/api/BSB/GEN/50.json']
+        numberOfChapters:
+          type: integer
         totalNumberOfVerses:
           type: integer
-          description: Total number of verses in the book
-
     ChapterResponse:
       type: object
       required:
+        - chapter
+        - thisChapterAudioLinks
         - translation
         - book
-        - chapter
         - thisChapterLink
+        - nextChapterApiLink
+        - nextChapterAudioLinks
+        - previousChapterApiLink
+        - previousChapterAudioLinks
         - numberOfVerses
       properties:
+        chapter:
+          $ref: '#/components/schemas/Chapter'
+        thisChapterAudioLinks:
+          $ref: '#/components/schemas/AudioLinks'
         translation:
           $ref: '#/components/schemas/Translation'
         book:
           $ref: '#/components/schemas/TranslationBook'
-        chapter:
-          $ref: '#/components/schemas/Chapter'
-        numberOfVerses:
-          type: integer
-          description: Number of verses in the chapter
         thisChapterLink:
           type: string
-          description: API path to this chapter
-          examples: ['/api/BSB/JHN/3.json']
-        thisChapterAudioLinks:
-          $ref: '#/components/schemas/AudioLinks'
         nextChapterApiLink:
-          type: string
-          description: API path to the next chapter, if any
+          type: [string, 'null']
         nextChapterAudioLinks:
-          $ref: '#/components/schemas/AudioLinks'
+          oneOf:
+            - $ref: '#/components/schemas/AudioLinks'
+            - type: 'null'
         previousChapterApiLink:
-          type: string
-          description: API path to the previous chapter, if any
+          type: [string, 'null']
         previousChapterAudioLinks:
-          $ref: '#/components/schemas/AudioLinks'
-
-    AudioLinks:
+          oneOf:
+            - $ref: '#/components/schemas/AudioLinks'
+            - type: 'null'
+        numberOfVerses:
+          type: integer
+    TranslationComplete:
       type: object
-      description: Map of reader name to audio file URL
-      additionalProperties:
-        type: string
-        format: uri
-
+      required: [translation, books]
+      properties:
+        translation:
+          $ref: '#/components/schemas/Translation'
+        books:
+          type: array
+          items:
+            $ref: '#/components/schemas/TranslationCompleteBook'
+    TranslationCompleteBook:
+      type: object
+      required:
+        - id
+        - name
+        - commonName
+        - title
+        - order
+        - numberOfChapters
+        - totalNumberOfVerses
+        - chapters
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        commonName:
+          type: string
+        title:
+          type: [string, 'null']
+        order:
+          type: integer
+        numberOfChapters:
+          type: integer
+        totalNumberOfVerses:
+          type: integer
+        isApocryphal:
+          type: boolean
+        chapters:
+          type: array
+          items:
+            $ref: '#/components/schemas/TranslationBookChapter'
+    Commentary:
+      type: object
+      required:
+        - id
+        - name
+        - website
+        - licenseUrl
+        - englishName
+        - language
+        - textDirection
+        - listOfBooksApiLink
+        - listOfProfilesApiLink
+        - availableFormats
+        - numberOfBooks
+        - totalNumberOfChapters
+        - totalNumberOfVerses
+        - totalNumberOfProfiles
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        website:
+          type: string
+        licenseUrl:
+          type: string
+        licenseNotes:
+          type: [string, 'null']
+        englishName:
+          type: string
+        language:
+          type: string
+          description: The ISO 639 letter language tag that the translation is primarily in.
+        textDirection:
+          type: string
+          enum: [ltr, rtl]
+        listOfBooksApiLink:
+          type: string
+        listOfProfilesApiLink:
+          type: string
+        availableFormats:
+          type: array
+          items:
+            type: string
+            enum: [json, usfm]
+        numberOfBooks:
+          type: integer
+        totalNumberOfChapters:
+          type: integer
+        totalNumberOfVerses:
+          type: integer
+        totalNumberOfProfiles:
+          type: integer
+        languageName:
+          type: string
+        languageEnglishName:
+          type: string
+    CommentaryBook:
+      type: object
+      required:
+        - id
+        - name
+        - commonName
+        - order
+        - firstChapterNumber
+        - firstChapterApiLink
+        - lastChapterNumber
+        - lastChapterApiLink
+        - numberOfChapters
+        - totalNumberOfVerses
+      properties:
+        id:
+          type: string
+          description: 'Defines an interface that contains information about a translation. / export interface Translation { /** The ID of the translation.'
+        name:
+          type: string
+        commonName:
+          type: string
+        introduction:
+          type: string
+        introductionSummary:
+          type: string
+        order:
+          type: integer
+        firstChapterNumber:
+          type: [integer, 'null']
+        firstChapterApiLink:
+          type: [string, 'null']
+        lastChapterNumber:
+          type: [integer, 'null']
+        lastChapterApiLink:
+          type: [string, 'null']
+        numberOfChapters:
+          type: integer
+        totalNumberOfVerses:
+          type: integer
+          description: 'The total number of chapters that are contained in this dataset. / totalNumberOfChapters: number; /** The total number of verses that are contained in this dataset.'
+    CommentaryBookChapter:
+      type: object
+      required:
+        - chapter
+        - commentary
+        - book
+        - thisChapterLink
+        - nextChapterApiLink
+        - previousChapterApiLink
+        - numberOfVerses
+      properties:
+        chapter:
+          $ref: '#/components/schemas/CommentaryChapter'
+        commentary:
+          $ref: '#/components/schemas/Commentary'
+        book:
+          $ref: '#/components/schemas/CommentaryBook'
+        thisChapterLink:
+          type: string
+        nextChapterApiLink:
+          type: [string, 'null']
+        previousChapterApiLink:
+          type: [string, 'null']
+        numberOfVerses:
+          type: integer
+    CommentaryProfileRef:
+      type: object
+      required: [id, subject, thisProfileLink]
+      properties:
+        id:
+          type: string
+        subject:
+          type: string
+        reference:
+          oneOf:
+            - type: object
+              properties:
+                book:
+                  type: string
+                chapter:
+                  type: integer
+                verse:
+                  type: integer
+            - type: 'null'
+        thisProfileLink:
+          type: string
+        referenceChapterLink:
+          type: [string, 'null']
+    CommentaryProfileContent:
+      type: object
+      required: [commentary, profile, content]
+      properties:
+        commentary:
+          $ref: '#/components/schemas/Commentary'
+        profile:
+          $ref: '#/components/schemas/CommentaryProfileRef'
+        content:
+          type: array
+          items:
+            type: string
+    Dataset:
+      type: object
+      required:
+        - id
+        - name
+        - website
+        - licenseUrl
+        - englishName
+        - language
+        - textDirection
+        - listOfBooksApiLink
+        - availableFormats
+        - numberOfBooks
+        - totalNumberOfChapters
+        - totalNumberOfVerses
+        - totalNumberOfReferences
+      properties:
+        id:
+          type: string
+          description: 'The metadata for a translation that is input into the generator. / export interface InputTranslationMetadata extends MetadataBase { /** The ID of the translation.'
+        name:
+          type: string
+        website:
+          type: string
+        licenseUrl:
+          type: string
+        licenseNotes:
+          type: [string, 'null']
+        englishName:
+          type: string
+        language:
+          type: string
+        textDirection:
+          type: string
+          enum: [ltr, rtl]
+        listOfBooksApiLink:
+          type: string
+        availableFormats:
+          type: array
+          items:
+            type: string
+            enum: [json]
+        numberOfBooks:
+          type: integer
+        totalNumberOfChapters:
+          type: integer
+        totalNumberOfVerses:
+          type: integer
+        totalNumberOfReferences:
+          type: integer
+        languageName:
+          type: string
+        languageEnglishName:
+          type: string
+    DatasetBook:
+      type: object
+      required:
+        - id
+        - order
+        - firstChapterNumber
+        - firstChapterApiLink
+        - lastChapterNumber
+        - lastChapterApiLink
+        - numberOfChapters
+        - totalNumberOfVerses
+        - totalNumberOfReferences
+      properties:
+        id:
+          type: string
+        order:
+          type: integer
+        firstChapterNumber:
+          type: integer
+        firstChapterApiLink:
+          type: string
+        lastChapterNumber:
+          type: integer
+        lastChapterApiLink:
+          type: string
+        numberOfChapters:
+          type: integer
+        totalNumberOfVerses:
+          type: integer
+        totalNumberOfReferences:
+          type: integer
+          description: The total number of references that are contained in this dataset.
+    DatasetBookChapter:
+      type: object
+      required:
+        - chapter
+        - dataset
+        - book
+        - thisChapterLink
+        - nextChapterApiLink
+        - previousChapterApiLink
+        - numberOfVerses
+        - numberOfReferences
+      properties:
+        chapter:
+          $ref: '#/components/schemas/DatasetChapterData'
+        dataset:
+          $ref: '#/components/schemas/Dataset'
+        book:
+          $ref: '#/components/schemas/DatasetBook'
+        thisChapterLink:
+          type: string
+        nextChapterApiLink:
+          type: [string, 'null']
+        previousChapterApiLink:
+          type: [string, 'null']
+        numberOfVerses:
+          type: integer
+        numberOfReferences:
+          type: integer
     Chapter:
       type: object
       required: [number, content, footnotes]
       properties:
         number:
           type: integer
-          description: Chapter number
         content:
           type: array
           items:
             $ref: '#/components/schemas/ChapterContent'
-          description: Ordered array of headings, verses, and line breaks
         footnotes:
           type: array
           items:
             $ref: '#/components/schemas/ChapterFootnote'
-          description: Footnotes referenced from verse content
-
+    CommentaryChapter:
+      type: object
+      required: [number, content]
+      properties:
+        number:
+          type: integer
+        introduction:
+          type: string
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChapterVerse'
     ChapterContent:
-      description: >
-        Discriminated union of chapter content elements.
-        Use the `type` field to determine the variant.
       oneOf:
-        - $ref: '#/components/schemas/ChapterVerse'
         - $ref: '#/components/schemas/ChapterHeading'
         - $ref: '#/components/schemas/ChapterLineBreak'
+        - $ref: '#/components/schemas/ChapterVerse'
         - $ref: '#/components/schemas/ChapterHebrewSubtitle'
       discriminator:
         propertyName: type
@@ -449,62 +761,164 @@ components:
           heading: '#/components/schemas/ChapterHeading'
           line_break: '#/components/schemas/ChapterLineBreak'
           hebrew_subtitle: '#/components/schemas/ChapterHebrewSubtitle'
-
-    ChapterVerse:
-      type: object
-      required: [type, number, content]
-      properties:
-        type:
-          type: string
-          const: verse
-        number:
-          type: integer
-          description: Verse number
-        content:
-          type: array
-          description: >
-            Verse content elements: plain text strings, formatted text,
-            footnote markers, inline headings, or inline line breaks.
-          items:
-            $ref: '#/components/schemas/VerseContentItem'
-
     ChapterHeading:
       type: object
       required: [type, content]
       properties:
         type:
           type: string
-          const: heading
+          enum: [heading]
         content:
           type: array
           items:
             type: string
           description: Heading text segments; concatenate with a space
-
     ChapterLineBreak:
       type: object
       required: [type]
       properties:
         type:
           type: string
-          const: line_break
-
+          enum: [line_break]
+    ChapterVerse:
+      type: object
+      required: [type, number, content]
+      properties:
+        type:
+          type: string
+          enum: [verse]
+        number:
+          type: integer
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/VerseContentItem'
     ChapterHebrewSubtitle:
       type: object
       required: [type, content]
       properties:
         type:
           type: string
-          const: hebrew_subtitle
+          enum: [hebrew_subtitle]
         content:
           type: array
-          description: Subtitle content — strings, formatted text, or footnote references
           items:
             oneOf:
               - type: string
               - $ref: '#/components/schemas/FormattedText'
               - $ref: '#/components/schemas/VerseFootnoteReference'
-
+    FormattedText:
+      type: object
+      required: [text]
+      properties:
+        text:
+          type: string
+        poem:
+          type: integer
+        wordsOfJesus:
+          type: boolean
+    InlineHeading:
+      type: object
+      required: [heading]
+      properties:
+        heading:
+          type: string
+    InlineLineBreak:
+      type: object
+      required: [lineBreak]
+      properties:
+        lineBreak:
+          type: boolean
+          const: true
+    VerseFootnoteReference:
+      type: object
+      required: [noteId]
+      properties:
+        noteId:
+          type: integer
+    ChapterFootnote:
+      type: object
+      required: [noteId, text, caller]
+      properties:
+        noteId:
+          type: integer
+        text:
+          type: string
+        reference:
+          type: object
+          properties:
+            chapter:
+              type: integer
+            verse:
+              type: integer
+          required: [chapter, verse]
+        caller:
+          oneOf:
+            - type: string
+              enum: [+]
+            - type: string
+    AudioLinks:
+      type: object
+      description: Map of reader name to audio file URL
+      additionalProperties:
+        type: string
+        format: uri
+    DatasetChapterData:
+      type: object
+      required: [number, content]
+      properties:
+        number:
+          type: integer
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatasetChapterVerseContent'
+    DatasetChapterVerseContent:
+      type: object
+      required: [verse, references]
+      properties:
+        verse:
+          type: integer
+        references:
+          type: array
+          items:
+            $ref: '#/components/schemas/CrossReference'
+    CrossReference:
+      type: object
+      required: [book, chapter, verse, score]
+      properties:
+        book:
+          type: string
+          description: USFM book identifier
+        chapter:
+          type: integer
+          description: Chapter number
+        verse:
+          type: integer
+          description: Verse number
+        score:
+          type: number
+          description: Relevance score
+    CommentaryProfile:
+      type: object
+      required: [id, subject, reference]
+      properties:
+        id:
+          type: string
+        subject:
+          type: string
+        reference:
+          oneOf:
+            - type: object
+              required: [book, chapter, verse]
+              properties:
+                book:
+                  type: string
+                chapter:
+                  type: integer
+                verse:
+                  type: integer
+            - type: 'null'
     VerseContentItem:
       description: A single element within verse content
       oneOf:
@@ -513,296 +927,3 @@ components:
         - $ref: '#/components/schemas/VerseFootnoteReference'
         - $ref: '#/components/schemas/InlineHeading'
         - $ref: '#/components/schemas/InlineLineBreak'
-
-    FormattedText:
-      type: object
-      required: [text]
-      description: Text with optional formatting metadata
-      properties:
-        text:
-          type: string
-          description: The formatted text content
-        poem:
-          type: integer
-          description: Poetry indent level (common in Psalms)
-        wordsOfJesus:
-          type: boolean
-          description: Whether this text represents the words of Jesus
-
-    VerseFootnoteReference:
-      type: object
-      required: [noteId]
-      description: Inline footnote marker; match noteId to ChapterFootnote
-      properties:
-        noteId:
-          type: integer
-          description: ID referencing a ChapterFootnote
-
-    InlineHeading:
-      type: object
-      required: [heading]
-      description: A heading embedded within a verse
-      properties:
-        heading:
-          type: string
-
-    InlineLineBreak:
-      type: object
-      required: [lineBreak]
-      description: A line break embedded within a verse
-      properties:
-        lineBreak:
-          type: boolean
-          const: true
-
-    ChapterFootnote:
-      type: object
-      required: [noteId, caller, text]
-      properties:
-        noteId:
-          type: integer
-          description: Unique footnote ID within the chapter
-        caller:
-          type: ['string', 'null']
-          description: >
-            Footnote caller character. "+" means auto-generate,
-            null means no caller, otherwise use the literal string.
-        text:
-          type: string
-          description: Footnote text content
-        reference:
-          type: object
-          description: Verse reference for the footnote
-          properties:
-            chapter:
-              type: integer
-            verse:
-              type: integer
-
-    Commentary:
-      type: object
-      required:
-        - id
-        - name
-        - englishName
-        - language
-        - listOfBooksApiLink
-        - numberOfBooks
-        - totalNumberOfChapters
-        - totalNumberOfVerses
-      properties:
-        id:
-          type: string
-          description: Unique commentary identifier
-          examples: ['cluv']
-        name:
-          type: string
-          description: Full name of the commentary
-        shortName:
-          type: string
-          description: Short name / abbreviation
-        englishName:
-          type: string
-          description: English name of the commentary
-        language:
-          type: string
-          description: ISO 639 3-letter language code
-          examples: ['eng']
-        listOfBooksApiLink:
-          type: string
-          description: API path to the commentary books list
-          examples: ['/api/c/cluv/books.json']
-        listOfProfilesApiLink:
-          type: string
-          description: API path to the profiles list
-        numberOfBooks:
-          type: integer
-          description: Total number of books in the commentary
-        totalNumberOfChapters:
-          type: integer
-          description: Total number of chapters across all books
-        totalNumberOfVerses:
-          type: integer
-          description: Total number of verses across all books
-
-    CommentaryBook:
-      type: object
-      required:
-        - id
-        - name
-        - commonName
-        - order
-        - numberOfChapters
-        - totalNumberOfVerses
-        - firstChapterApiLink
-      properties:
-        id:
-          type: string
-          description: USFM book identifier
-          examples: ['GEN']
-        name:
-          type: string
-          description: Book name as provided by the commentary
-          examples: ['Genesis']
-        commonName:
-          type: string
-          description: Common English name for the book
-          examples: ['Genesis']
-        order:
-          type: integer
-          description: Numerical order of the book
-          examples: [1]
-        numberOfChapters:
-          type: integer
-          description: Number of chapters in the book
-        totalNumberOfVerses:
-          type: integer
-          description: Total number of verses in the book
-        firstChapterApiLink:
-          type: string
-          description: API path to the first chapter
-          examples: ['/api/c/cluv/GEN/1.json']
-
-    CommentaryBookChapter:
-      type: object
-      required:
-        - commentary
-        - book
-        - chapter
-        - thisChapterLink
-        - numberOfVerses
-      properties:
-        commentary:
-          $ref: '#/components/schemas/Commentary'
-        book:
-          $ref: '#/components/schemas/CommentaryBook'
-        chapter:
-          $ref: '#/components/schemas/Chapter'
-        thisChapterLink:
-          type: string
-          description: API path to this chapter
-          examples: ['/api/c/cluv/GEN/1.json']
-        nextChapterApiLink:
-          type: string
-          description: API path to the next chapter, if any
-        previousChapterApiLink:
-          type: string
-          description: API path to the previous chapter, if any
-        numberOfVerses:
-          type: integer
-          description: Number of verses in the chapter
-
-    Dataset:
-      type: object
-      required:
-        - id
-        - name
-        - englishName
-        - language
-        - listOfBooksApiLink
-        - numberOfBooks
-        - totalNumberOfReferences
-      properties:
-        id:
-          type: string
-          description: Unique dataset identifier
-          examples: ['cross-references']
-        name:
-          type: string
-          description: Full name of the dataset
-        shortName:
-          type: string
-          description: Short name / abbreviation
-        englishName:
-          type: string
-          description: English name of the dataset
-        language:
-          type: string
-          description: ISO 639 3-letter language code
-          examples: ['eng']
-        listOfBooksApiLink:
-          type: string
-          description: API path to the dataset books list
-          examples: ['/api/d/cross-references/books.json']
-        numberOfBooks:
-          type: integer
-          description: Total number of books in the dataset
-        totalNumberOfReferences:
-          type: integer
-          description: Total number of cross-references in the dataset
-
-    DatasetBook:
-      type: object
-      required:
-        - id
-        - name
-        - numberOfChapters
-        - totalNumberOfReferences
-        - firstChapterApiLink
-      properties:
-        id:
-          type: string
-          description: USFM book identifier
-          examples: ['GEN']
-        name:
-          type: string
-          description: Book name
-          examples: ['Genesis']
-        numberOfChapters:
-          type: integer
-          description: Number of chapters in the book
-        totalNumberOfReferences:
-          type: integer
-          description: Total number of cross-references in the book
-        firstChapterApiLink:
-          type: string
-          description: API path to the first chapter
-          examples: ['/api/d/cross-references/GEN/1.json']
-
-    DatasetBookChapter:
-      type: object
-      required:
-        - dataset
-        - book
-        - chapter
-      properties:
-        dataset:
-          $ref: '#/components/schemas/Dataset'
-        book:
-          $ref: '#/components/schemas/DatasetBook'
-        chapter:
-          type: object
-          required: [number, content]
-          properties:
-            number:
-              type: integer
-              description: Chapter number
-            content:
-              type: array
-              description: Verse-level cross-references
-              items:
-                type: object
-                required: [verse, references]
-                properties:
-                  verse:
-                    type: integer
-                    description: Verse number
-                  references:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/CrossReference'
-
-    CrossReference:
-      type: object
-      required: [book, chapter, verse]
-      properties:
-        book:
-          type: string
-          description: USFM book identifier
-          examples: ['JHN']
-        chapter:
-          type: integer
-          description: Chapter number
-        verse:
-          type: integer
-          description: Verse number

--- a/scripts/generate_client.py
+++ b/scripts/generate_client.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""
+generate_client.py — Read an OpenAPI 3.1.0 JSON spec and generate a Python
+client package with typed dataclasses and HTTP methods.
+
+Usage: python3 scripts/generate_client.py <spec.json> <output_dir>
+
+Only uses Python stdlib (no pip packages).
+"""
+
+import json
+import os
+import re
+import sys
+import textwrap
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def resolve_ref(spec, ref):
+    """Resolve a $ref string like '#/components/schemas/Foo' against the spec."""
+    parts = ref.lstrip('#/').split('/')
+    node = spec
+    for p in parts:
+        if isinstance(node, dict):
+            node = node.get(p)
+        else:
+            return None
+    return node
+
+
+def ref_name(ref_str):
+    """Extract the schema name from a $ref string."""
+    return ref_str.split('/')[-1]
+
+
+def to_snake_case(name):
+    """Convert camelCase/PascalCase to snake_case."""
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+
+SIMPLE_TYPE_MAP = {
+    'string': 'str',
+    'integer': 'int',
+    'number': 'float',
+    'boolean': 'bool',
+}
+
+
+def schema_to_python_type(schema, spec):
+    """Convert an OpenAPI schema to a Python type annotation string."""
+    if schema is None:
+        return 'Any'
+
+    if '$ref' in schema:
+        return ref_name(schema['$ref'])
+
+    one_of = schema.get('oneOf')
+    schema_type = schema.get('type')
+
+    # oneOf handling
+    if one_of:
+        types = []
+        has_null = False
+        for s in one_of:
+            if isinstance(s, dict) and s.get('type') == 'null':
+                has_null = True
+            else:
+                types.append(schema_to_python_type(s, spec))
+        if len(types) == 1 and has_null:
+            return f'Optional[{types[0]}]'
+        if len(types) > 1:
+            type_str = f'Union[{", ".join(types)}]'
+        elif types:
+            type_str = types[0]
+        else:
+            type_str = 'Any'
+        return f'Optional[{type_str}]' if has_null else type_str
+
+    # type: [string, null] shorthand
+    if isinstance(schema_type, list):
+        non_null = [t for t in schema_type if t != 'null']
+        has_null = 'null' in schema_type
+        if len(non_null) == 1:
+            base = SIMPLE_TYPE_MAP.get(non_null[0], 'Any')
+            return f'Optional[{base}]' if has_null else base
+        return 'Any'
+
+    if schema_type == 'array':
+        items = schema.get('items', {})
+        item_type = schema_to_python_type(items, spec)
+        return f'List[{item_type}]'
+
+    if schema_type == 'object':
+        if 'additionalProperties' in schema:
+            val_type = schema_to_python_type(schema['additionalProperties'], spec)
+            return f'Dict[str, {val_type}]'
+        if 'properties' not in schema:
+            return 'Dict[str, Any]'
+        return 'Dict[str, Any]'
+
+    if schema_type in SIMPLE_TYPE_MAP:
+        return SIMPLE_TYPE_MAP[schema_type]
+
+    return 'Any'
+
+
+# ---------------------------------------------------------------------------
+# models.py generator
+# ---------------------------------------------------------------------------
+
+def generate_models(spec):
+    """Generate models.py content from component schemas."""
+    schemas = spec.get('components', {}).get('schemas', {})
+
+    lines = [
+        '"""Auto-generated dataclass models from OpenAPI spec."""',
+        'from __future__ import annotations',
+        '',
+        'from dataclasses import dataclass, field',
+        'from typing import Any, Dict, List, Optional, Union',
+        '',
+        '',
+    ]
+
+    # Collect which schemas are object types with properties
+    object_schemas = []
+    alias_schemas = []
+
+    for name, schema in schemas.items():
+        if not isinstance(schema, dict):
+            continue
+        s_type = schema.get('type')
+        one_of = schema.get('oneOf')
+
+        # Union type alias (oneOf without being an object)
+        if one_of and s_type != 'object':
+            alias_schemas.append((name, schema))
+            continue
+
+        # Object with additionalProperties only (like AudioLinks) -> type alias
+        if s_type == 'object' and 'properties' not in schema:
+            alias_schemas.append((name, schema))
+            continue
+
+        if s_type == 'object' and 'properties' in schema:
+            object_schemas.append((name, schema))
+
+    # Generate dataclasses (before type aliases, since aliases reference classes)
+    for name, schema in object_schemas:
+        properties = schema.get('properties', {})
+        required = set(schema.get('required', []))
+
+        lines.append('@dataclass')
+        lines.append(f'class {name}:')
+
+        if not properties:
+            lines.append('    pass')
+            lines.append('')
+            lines.append('')
+            continue
+
+        # Required fields first, then optional (dataclass ordering)
+        req_fields = [(k, v) for k, v in properties.items() if k in required]
+        opt_fields = [(k, v) for k, v in properties.items() if k not in required]
+
+        for field_name, field_schema in req_fields:
+            py_type = schema_to_python_type(field_schema, spec)
+            py_field = to_snake_case(field_name)
+            if py_field != field_name:
+                lines.append(f'    {py_field}: {py_type}  # json: {field_name}')
+            else:
+                lines.append(f'    {py_field}: {py_type}')
+
+        for field_name, field_schema in opt_fields:
+            py_type = schema_to_python_type(field_schema, spec)
+            py_field = to_snake_case(field_name)
+            if not py_type.startswith('Optional'):
+                py_type = f'Optional[{py_type}]'
+            if py_field != field_name:
+                lines.append(f'    {py_field}: {py_type} = None  # json: {field_name}')
+            else:
+                lines.append(f'    {py_field}: {py_type} = None')
+
+        lines.append('')
+        lines.append('')
+
+    # Generate type aliases AFTER dataclasses (aliases reference class names)
+    if alias_schemas:
+        lines.append('')
+        lines.append('# Type aliases (must be after class definitions)')
+        for name, schema in alias_schemas:
+            py_type = schema_to_python_type(schema, spec)
+            lines.append(f'{name} = {py_type}')
+        lines.append('')
+
+    return '\n'.join(lines)
+
+
+# ---------------------------------------------------------------------------
+# client.py generator
+# ---------------------------------------------------------------------------
+
+def generate_client(spec):
+    """Generate client.py content with BibleAPIClient."""
+    servers = spec.get('servers', [])
+    base_url = servers[0]['url'] if servers else 'https://bible.helloao.org'
+    paths = spec.get('paths', {})
+
+    lines = [
+        '"""Auto-generated API client from OpenAPI spec."""',
+        'from __future__ import annotations',
+        '',
+        'import json',
+        'import urllib.request',
+        'import urllib.error',
+        'from typing import Any, Dict, List, Optional',
+        '',
+        'from .models import *',
+        '',
+        '',
+        'class APIError(Exception):',
+        '    """Raised when an API request fails."""',
+        '',
+        '    def __init__(self, message: str, status_code: Optional[int] = None):',
+        '        super().__init__(message)',
+        '        self.status_code = status_code',
+        '',
+        '',
+    ]
+
+    # Collect all schema names for from_dict helpers
+    schemas = spec.get('components', {}).get('schemas', {})
+    object_schema_names = set()
+    for name, schema in schemas.items():
+        if isinstance(schema, dict) and schema.get('type') == 'object' and 'properties' in schema:
+            object_schema_names.add(name)
+
+    lines.append('def _from_dict(cls, data):')
+    lines.append('    """Recursively construct a dataclass from a dict."""')
+    lines.append('    if data is None or not isinstance(data, dict):')
+    lines.append('        return data')
+    lines.append('    import dataclasses')
+    lines.append('    if not dataclasses.is_dataclass(cls):')
+    lines.append('        return data')
+    lines.append('    field_map = {}')
+    lines.append('    for f in dataclasses.fields(cls):')
+    lines.append('        # Check the comment for the original json key name')
+    lines.append('        field_map[f.name] = f')
+    lines.append('    kwargs = {}')
+    lines.append('    # Build reverse map: json_key -> field')
+    lines.append('    json_to_field = {}')
+    lines.append('    for f in dataclasses.fields(cls):')
+    lines.append('        if f.metadata and "json_key" in f.metadata:')
+    lines.append('            json_to_field[f.metadata["json_key"]] = f')
+    lines.append('        json_to_field[f.name] = f')
+    lines.append('    for key, val in data.items():')
+    lines.append('        snake = key')
+    lines.append('        # Try camelCase -> snake_case')
+    lines.append('        import re')
+    lines.append('        s1 = re.sub("(.)([A-Z][a-z]+)", r"\\1_\\2", key)')
+    lines.append('        snake = re.sub("([a-z0-9])([A-Z])", r"\\1_\\2", s1).lower()')
+    lines.append('        if snake in field_map:')
+    lines.append('            kwargs[snake] = val')
+    lines.append('        elif key in field_map:')
+    lines.append('            kwargs[key] = val')
+    lines.append('    return cls(**kwargs)')
+    lines.append('')
+    lines.append('')
+
+    # Client class
+    lines.append('class BibleAPIClient:')
+    lines.append('    """Auto-generated client for the helloao.org Bible API."""')
+    lines.append('')
+    lines.append(f'    DEFAULT_BASE_URL = "{base_url}"')
+    lines.append('')
+    lines.append('    def __init__(self, base_url: Optional[str] = None, timeout: int = 30):')
+    lines.append('        self.base_url = (base_url or self.DEFAULT_BASE_URL).rstrip("/")')
+    lines.append('        self.timeout = timeout')
+    lines.append('')
+    lines.append('    def _request(self, path: str) -> Any:')
+    lines.append('        """Make a GET request and return parsed JSON."""')
+    lines.append('        url = self.base_url + path')
+    lines.append('        req = urllib.request.Request(url, headers={"Accept": "application/json"})')
+    lines.append('        try:')
+    lines.append('            with urllib.request.urlopen(req, timeout=self.timeout) as resp:')
+    lines.append('                return json.loads(resp.read().decode("utf-8"))')
+    lines.append('        except urllib.error.HTTPError as e:')
+    lines.append('            raise APIError(f"HTTP {e.code}: {e.reason}", e.code) from e')
+    lines.append('        except urllib.error.URLError as e:')
+    lines.append('            raise APIError(f"Connection error: {e.reason}") from e')
+    lines.append('')
+
+    # Generate methods for each endpoint
+    for path_str, path_obj in paths.items():
+        for method, op in path_obj.items():
+            if method not in ('get', 'post', 'put', 'delete', 'patch'):
+                continue
+            op_id = op.get('operationId')
+            if not op_id:
+                continue
+
+            method_name = to_snake_case(op_id)
+            summary = op.get('summary', '')
+            params = op.get('parameters', [])
+
+            # Resolve parameter refs
+            resolved_params = []
+            for p in params:
+                if '$ref' in p:
+                    resolved = resolve_ref(spec, p['$ref'])
+                    if resolved:
+                        resolved_params.append(resolved)
+                else:
+                    resolved_params.append(p)
+
+            # Build method signature
+            param_parts = []
+            for p in resolved_params:
+                pname = to_snake_case(p['name'])
+                ptype = SIMPLE_TYPE_MAP.get(p.get('schema', {}).get('type', 'string'), 'str')
+                param_parts.append((pname, ptype, p['name']))
+
+            sig_args = ['self'] + [f'{pn}: {pt}' for pn, pt, _ in param_parts]
+
+            # Determine return type from response schema
+            resp_200 = op.get('responses', {}).get('200', {})
+            resp_schema = resp_200.get('content', {}).get('application/json', {}).get('schema', {})
+            return_type = 'Dict[str, Any]'
+            return_model = None
+            if '$ref' in resp_schema:
+                rname = ref_name(resp_schema['$ref'])
+                if rname in object_schema_names:
+                    return_type = rname
+                    return_model = rname
+
+            lines.append(f'    def {method_name}({", ".join(sig_args)}) -> {return_type}:')
+            lines.append(f'        """{summary}"""')
+
+            # Build URL path
+            url_path = path_str
+            for pn, _, orig in param_parts:
+                url_path = url_path.replace('{' + orig + '}', '{' + pn + '}')
+
+            if param_parts:
+                lines.append(f'        path = f"{url_path}"')
+            else:
+                lines.append(f'        path = "{url_path}"')
+
+            if return_model:
+                lines.append(f'        return _from_dict({return_model}, self._request(path))')
+            else:
+                lines.append(f'        return self._request(path)')
+            lines.append('')
+
+    return '\n'.join(lines)
+
+
+# ---------------------------------------------------------------------------
+# __init__.py generator
+# ---------------------------------------------------------------------------
+
+def generate_init(spec):
+    """Generate __init__.py that re-exports the client and models."""
+    schemas = spec.get('components', {}).get('schemas', {})
+
+    model_names = []
+    for name, schema in schemas.items():
+        if not isinstance(schema, dict):
+            continue
+        if schema.get('type') == 'object' and 'properties' in schema:
+            model_names.append(name)
+
+    lines = [
+        '"""Auto-generated Python client for the helloao.org Bible API."""',
+        '',
+        'from .client import APIError, BibleAPIClient, _from_dict',
+        'from .models import *',
+        '',
+        f'__all__ = ["APIError", "BibleAPIClient"] + {model_names!r}',
+        '',
+    ]
+    return '\n'.join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    if len(sys.argv) < 3:
+        print(f'Usage: {sys.argv[0]} <spec.json> <output_dir>', file=sys.stderr)
+        sys.exit(1)
+
+    spec_path = sys.argv[1]
+    output_dir = sys.argv[2]
+
+    with open(spec_path, 'r') as f:
+        spec = json.load(f)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Generate models.py
+    models_path = os.path.join(output_dir, 'models.py')
+    with open(models_path, 'w') as f:
+        f.write(generate_models(spec))
+    print(f'Generated {models_path}', file=sys.stderr)
+
+    # Generate client.py
+    client_path = os.path.join(output_dir, 'client.py')
+    with open(client_path, 'w') as f:
+        f.write(generate_client(spec))
+    print(f'Generated {client_path}', file=sys.stderr)
+
+    # Generate __init__.py
+    init_path = os.path.join(output_dir, '__init__.py')
+    with open(init_path, 'w') as f:
+        f.write(generate_init(spec))
+    print(f'Generated {init_path}', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate_spec.js
+++ b/scripts/generate_spec.js
@@ -1,0 +1,1018 @@
+#!/usr/bin/env node
+/**
+ * generate_spec.js — Parse vendor/api.ts + vendor/common-types.ts and emit
+ * an OpenAPI 3.1.0 YAML spec to stdout.
+ *
+ * No TypeScript compiler required — uses regex/string parsing.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const API_TS = fs.readFileSync(path.join(ROOT, 'vendor/api.ts'), 'utf8');
+const COMMON_TS = fs.readFileSync(path.join(ROOT, 'vendor/common-types.ts'), 'utf8');
+const CHANGELOG = fs.readFileSync(path.join(ROOT, 'vendor/API-CHANGELOG.md'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// 1. Extract version from changelog
+// ---------------------------------------------------------------------------
+const versionMatch = CHANGELOG.match(/^## V(\d+\.\d+\.\d+)/m);
+const API_VERSION = versionMatch ? versionMatch[1] : '0.0.0';
+
+// ---------------------------------------------------------------------------
+// 2. Parse TypeScript interfaces
+// ---------------------------------------------------------------------------
+
+/** Strip single-line and block comments (but preserve string literals). */
+function stripComments(src) {
+  // Remove block comments
+  let out = src.replace(/\/\*[\s\S]*?\*\//g, '');
+  // Remove single-line comments
+  out = out.replace(/\/\/.*$/gm, '');
+  return out;
+}
+
+/**
+ * Extract JSDoc description for a field from the raw (un-stripped) source.
+ * Returns the comment text immediately before the field declaration at the given position.
+ */
+function extractFieldComment(rawSrc, fieldName, searchStart, searchEnd) {
+  const region = rawSrc.slice(searchStart, searchEnd);
+  // Find the field and look for JSDoc before it
+  const fieldPattern = new RegExp(`\\/\\*\\*([\\s\\S]*?)\\*\\/\\s*(?:\\n\\s*)*${fieldName}\\??\\s*:`);
+  const m = region.match(fieldPattern);
+  if (!m) return null;
+  // Clean up the JSDoc
+  return m[1]
+    .split('\n')
+    .map(l => l.replace(/^\s*\*\s?/, '').trim())
+    .filter(l => l && !l.startsWith('@'))
+    .join(' ')
+    .trim();
+}
+
+/**
+ * Parse all interface/type declarations from TS source.
+ * Returns { name: { extends: string|null, fields: [{name, type, optional, description}], isType, typeValue } }
+ */
+function parseDeclarations(rawSrc) {
+  const src = stripComments(rawSrc);
+  const decls = {};
+
+  // Parse interfaces
+  const ifaceRe = /export\s+interface\s+(\w+)(?:\s+extends\s+([\w\s,]+))?\s*\{/g;
+  let m;
+  while ((m = ifaceRe.exec(src)) !== null) {
+    const name = m[1];
+    const extendsClause = m[2] ? m[2].split(',').map(s => s.trim()).filter(Boolean) : [];
+    const bodyStart = m.index + m[0].length;
+    const body = extractBracedBlock(src, bodyStart);
+    const fields = parseFields(body, rawSrc, m.index, m.index + m[0].length + body.length);
+    decls[name] = { extends: extendsClause, fields, isType: false };
+  }
+
+  // Parse type aliases that are unions of interfaces (discriminated unions)
+  const typeRe = /export\s+type\s+(\w+)\s*=\s*([^;]+);/g;
+  while ((m = typeRe.exec(src)) !== null) {
+    const name = m[1];
+    const value = m[2].trim();
+    decls[name] = { extends: [], fields: [], isType: true, typeValue: value };
+  }
+
+  return decls;
+}
+
+/** Extract the body of a brace-delimited block starting right after the opening brace. */
+function extractBracedBlock(src, start) {
+  let depth = 1;
+  let i = start;
+  while (i < src.length && depth > 0) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i - 1);
+}
+
+/** Parse fields from an interface body string. */
+function parseFields(body, rawSrc, rawStart, rawBodyStart) {
+  const fields = [];
+  // Match top-level fields: name?: type;
+  // Also handle index signatures: [key: type]: type;
+  const lines = body.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i].trim();
+
+    // Index signature: [key: string]: valueType
+    const indexMatch = line.match(/^\[(\w+)\s*:\s*(\w+)\]\s*:\s*(.+?)\s*;?\s*$/);
+    if (indexMatch) {
+      fields.push({
+        name: '__indexSignature',
+        keyType: indexMatch[2],
+        type: indexMatch[3].replace(/;$/, '').trim(),
+        optional: false,
+        isIndex: true,
+      });
+      i++;
+      continue;
+    }
+
+    // Regular field: name?: type;
+    // Handle multi-line types by collecting until we find a semicolon
+    const fieldStart = line.match(/^(\w+)(\??)\s*:\s*/);
+    if (fieldStart) {
+      const fieldName = fieldStart[1];
+      const optional = fieldStart[2] === '?';
+      let typeStr = line.slice(fieldStart[0].length);
+
+      // If type contains an opening brace, collect the inline object
+      if (typeStr.includes('{') && !typeStr.includes('}')) {
+        i++;
+        while (i < lines.length) {
+          typeStr += ' ' + lines[i].trim();
+          if (lines[i].includes('}')) {
+            // Check if the brace closes the inline object
+            const opens = (typeStr.match(/\{/g) || []).length;
+            const closes = (typeStr.match(/\}/g) || []).length;
+            if (closes >= opens) break;
+          }
+          i++;
+        }
+      }
+
+      // If type has unbalanced parens (multi-line union in parens), collect more
+      if (typeStr.includes('(') && !typeStr.includes(')')) {
+        i++;
+        while (i < lines.length) {
+          typeStr += ' ' + lines[i].trim();
+          if (typeStr.includes(')')) break;
+          i++;
+        }
+      }
+
+      typeStr = typeStr.replace(/;\s*$/, '').trim();
+      const desc = extractFieldComment(rawSrc, fieldName, rawStart, rawBodyStart + body_offset(body, fieldName));
+
+      fields.push({ name: fieldName, type: typeStr, optional, description: desc });
+    }
+    i++;
+  }
+  return fields;
+}
+
+function body_offset(body, fieldName) {
+  const idx = body.indexOf(fieldName);
+  return idx >= 0 ? idx : body.length;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Resolve inheritance and build schemas
+// ---------------------------------------------------------------------------
+
+const commonDecls = parseDeclarations(COMMON_TS);
+const apiDecls = parseDeclarations(API_TS);
+const allDecls = { ...commonDecls, ...apiDecls };
+
+/** Resolve all fields for a declaration, including inherited ones. */
+function resolveFields(name, seen = new Set()) {
+  if (seen.has(name)) return [];
+  seen.add(name);
+  const decl = allDecls[name];
+  if (!decl) return [];
+  let fields = [];
+  for (const parent of (decl.extends || [])) {
+    fields = fields.concat(resolveFields(parent, seen));
+  }
+  fields = fields.concat(decl.fields);
+  return fields;
+}
+
+/** Convert a TS type string to an OpenAPI schema object. */
+function tsTypeToSchema(typeStr) {
+  typeStr = typeStr.trim();
+
+  // Remove trailing semicolons
+  typeStr = typeStr.replace(/;$/, '').trim();
+
+  // Parenthesized union: ( A | B | C )[]
+  const parenUnionArr = typeStr.match(/^\(([^)]+)\)\[\]$/);
+  if (parenUnionArr) {
+    const inner = parenUnionArr[1];
+    return { type: 'array', items: tsTypeToSchema(inner) };
+  }
+
+  // Array type: Type[]
+  const arrMatch = typeStr.match(/^(.+)\[\]$/);
+  if (arrMatch) {
+    const inner = arrMatch[1].trim();
+    // Handle union arrays like ('json' | 'usfm')[]
+    if (inner.startsWith('(') && inner.endsWith(')')) {
+      return { type: 'array', items: tsTypeToSchema(inner.slice(1, -1)) };
+    }
+    return { type: 'array', items: tsTypeToSchema(inner) };
+  }
+
+  // String literal union: 'a' | 'b' | 'c'
+  if (/^'[^']*'(\s*\|\s*'[^']*')*$/.test(typeStr)) {
+    const values = typeStr.match(/'([^']*)'/g).map(s => s.slice(1, -1));
+    return { type: 'string', enum: values };
+  }
+
+  // Single string literal: 'value'
+  if (/^'([^']*)'$/.test(typeStr)) {
+    const val = typeStr.slice(1, -1);
+    return { type: 'string', const: val };
+  }
+
+  // Union with null: Type | null
+  const nullUnion = typeStr.match(/^(.+?)\s*\|\s*null$/);
+  if (nullUnion) {
+    const inner = tsTypeToSchema(nullUnion[1].trim());
+    if (inner.type) {
+      return { type: [inner.type, 'null'], ...(inner.enum ? { enum: inner.enum } : {}), ...(inner.const !== undefined ? { const: inner.const } : {}) };
+    }
+    if (inner.$ref) {
+      return { oneOf: [inner, { type: 'null' }] };
+    }
+    return inner;
+  }
+
+  // null | Type
+  const nullFirst = typeStr.match(/^null\s*\|\s*(.+)$/);
+  if (nullFirst) {
+    return tsTypeToSchema(nullFirst[1].trim() + ' | null');
+  }
+
+  // Union of types (not string literals, not null): A | B | C
+  if (typeStr.includes('|') && !typeStr.startsWith('(')) {
+    const parts = typeStr.split('|').map(s => s.trim());
+    // Check if it's all string literals
+    if (parts.every(p => /^'[^']*'$/.test(p))) {
+      return { type: 'string', enum: parts.map(p => p.slice(1, -1)) };
+    }
+    // Mixed union - use oneOf
+    const schemas = parts.filter(p => p !== 'null').map(p => tsTypeToSchema(p));
+    if (parts.includes('null')) {
+      return { oneOf: [...schemas, { type: 'null' }] };
+    }
+    return { oneOf: schemas };
+  }
+
+  // Inline object: { key: type; ... }
+  if (typeStr.startsWith('{') && typeStr.endsWith('}')) {
+    const inner = typeStr.slice(1, -1).trim();
+    const props = {};
+    const required = [];
+    const fieldRe = /(\w+)(\??):\s*([^;]+)/g;
+    let fm;
+    while ((fm = fieldRe.exec(inner)) !== null) {
+      props[fm[1]] = tsTypeToSchema(fm[3].trim());
+      if (fm[2] !== '?') required.push(fm[1]);
+    }
+    const schema = { type: 'object', properties: props };
+    if (required.length > 0) schema.required = required;
+    return schema;
+  }
+
+  // Primitive types
+  if (typeStr === 'string') return { type: 'string' };
+  if (typeStr === 'number') return { type: 'integer' };
+  if (typeStr === 'boolean') return { type: 'boolean' };
+  if (typeStr === 'true') return { type: 'boolean', const: true };
+  if (typeStr === 'any' || typeStr === 'object') return { type: 'object' };
+
+  // Reference to another interface
+  if (/^\w+$/.test(typeStr) && allDecls[typeStr]) {
+    return { $ref: `#/components/schemas/${typeStr}` };
+  }
+
+  // Fallback
+  return { type: 'string' };
+}
+
+/** Build an OpenAPI schema for a declaration. */
+function buildSchema(name) {
+  const decl = allDecls[name];
+  if (!decl) return null;
+
+  // Type alias (discriminated union)
+  if (decl.isType) {
+    const parts = decl.typeValue.split('|').map(s => s.trim()).filter(Boolean);
+    // Check if it's a union of known interfaces
+    const refs = parts.filter(p => allDecls[p]);
+    if (refs.length === parts.length && refs.length > 1) {
+      return { oneOf: refs.map(r => ({ $ref: `#/components/schemas/${r}` })) };
+    }
+    // Simple type alias
+    if (parts.length === 1) {
+      return tsTypeToSchema(parts[0]);
+    }
+    return tsTypeToSchema(decl.typeValue);
+  }
+
+  const fields = resolveFields(name);
+  const properties = {};
+  const required = [];
+  let additionalProperties = null;
+
+  for (const field of fields) {
+    if (field.isIndex) {
+      additionalProperties = tsTypeToSchema(field.type);
+      continue;
+    }
+    properties[field.name] = tsTypeToSchema(field.type);
+    if (field.description) {
+      properties[field.name].description = field.description;
+    }
+    if (!field.optional) {
+      required.push(field.name);
+    }
+  }
+
+  const schema = { type: 'object' };
+  if (required.length > 0) schema.required = required;
+  schema.properties = properties;
+  if (additionalProperties) schema.additionalProperties = additionalProperties;
+  return schema;
+}
+
+// ---------------------------------------------------------------------------
+// 4. Determine which schemas to include
+// ---------------------------------------------------------------------------
+
+// The API-facing types we want as top-level schemas:
+const API_SCHEMAS = [
+  // Translation types
+  'ApiTranslation', 'ApiTranslationBook', 'ApiTranslationBookChapter',
+  'ApiTranslationComplete', 'ApiTranslationCompleteBook',
+  // Commentary types
+  'ApiCommentary', 'ApiCommentaryBook', 'ApiCommentaryBookChapter',
+  'ApiCommentaryProfile', 'ApiCommentaryProfileContent',
+  // Dataset types
+  'ApiDataset', 'ApiDatasetBook', 'ApiDatasetBookChapter',
+  // Chapter data
+  'ChapterData', 'CommentaryChapterData',
+  'ChapterContent', 'ChapterHeading', 'ChapterLineBreak',
+  'ChapterVerse', 'ChapterHebrewSubtitle',
+  'FormattedText', 'InlineHeading', 'InlineLineBreak',
+  'VerseFootnoteReference', 'ChapterFootnote',
+  'TranslationBookChapterAudioLinks',
+  // Dataset chapter data
+  'DatasetChapterData', 'DatasetChapterVerseContent', 'ScoredVerseRef',
+  // Commentary profile
+  'CommentaryProfile',
+];
+
+// Build all schemas
+const schemas = {};
+for (const name of API_SCHEMAS) {
+  const schema = buildSchema(name);
+  if (schema) {
+    schemas[name] = schema;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. YAML serializer
+// ---------------------------------------------------------------------------
+
+function toYaml(obj, indent = 0) {
+  if (obj === null) return 'null';
+  if (obj === undefined) return 'null';
+  if (typeof obj === 'boolean') return obj.toString();
+  if (typeof obj === 'number') return obj.toString();
+  if (typeof obj === 'string') {
+    // Needs quoting if it contains special chars, is a boolean/null word, or is empty
+    if (/^(true|false|null|yes|no)$/i.test(obj) || obj === '' ||
+        /[:#\[\]{}&*!|>'"%@`]/.test(obj) || /^\d/.test(obj) ||
+        obj.includes('\n')) {
+      return "'" + obj.replace(/'/g, "''") + "'";
+    }
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) return '[]';
+    // Use flow style for simple arrays (strings/numbers only, short)
+    if (obj.every(i => typeof i === 'string' || typeof i === 'number') && JSON.stringify(obj).length < 60) {
+      return '[' + obj.map(i => {
+        if (typeof i === 'string') {
+          if (/^(true|false|null)$/i.test(i) || /[:#\[\]{}&*!|>'"%@`]/.test(i)) {
+            return "'" + i.replace(/'/g, "''") + "'";
+          }
+          return i;
+        }
+        return String(i);
+      }).join(', ') + ']';
+    }
+    const pad = '  '.repeat(indent);
+    return obj.map(item => {
+      if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
+        const entries = Object.entries(item);
+        if (entries.length === 0) return `${pad}- {}`;
+        const first = entries[0];
+        let result = `${pad}- ${first[0]}: ${toYaml(first[1], indent + 2)}`;
+        for (let j = 1; j < entries.length; j++) {
+          const val = toYaml(entries[j][1], indent + 2);
+          if (typeof entries[j][1] === 'object' && entries[j][1] !== null && !isFlowable(entries[j][1])) {
+            result += `\n${pad}  ${entries[j][0]}:\n${val}`;
+          } else {
+            result += `\n${pad}  ${entries[j][0]}: ${val}`;
+          }
+        }
+        return result;
+      }
+      return `${pad}- ${toYaml(item, indent + 1)}`;
+    }).join('\n');
+  }
+  // Object
+  const entries = Object.entries(obj);
+  if (entries.length === 0) return '{}';
+  const pad = '  '.repeat(indent);
+  return entries.map(([key, value]) => {
+    if (value === undefined) return null;
+    const yamlKey = /[:#\[\]{}&*!|>'"%@`,]/.test(key) || /^\d/.test(key) ? `'${key}'` : key;
+    if (typeof value === 'object' && value !== null && !isFlowable(value)) {
+      return `${pad}${yamlKey}:\n${toYaml(value, indent + 1)}`;
+    }
+    return `${pad}${yamlKey}: ${toYaml(value, indent + 1)}`;
+  }).filter(Boolean).join('\n');
+}
+
+function isFlowable(obj) {
+  if (Array.isArray(obj)) {
+    return obj.every(i => typeof i === 'string' || typeof i === 'number') && JSON.stringify(obj).length < 60;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// 6. Build the OpenAPI document
+// ---------------------------------------------------------------------------
+
+// Rename Api-prefixed schemas to friendlier names for the spec
+const SCHEMA_RENAMES = {
+  'ApiTranslation': 'Translation',
+  'ApiTranslationBook': 'TranslationBook',
+  'ApiTranslationBookChapter': 'ChapterResponse',
+  'ApiTranslationComplete': 'TranslationComplete',
+  'ApiTranslationCompleteBook': 'TranslationCompleteBook',
+  'ApiCommentary': 'Commentary',
+  'ApiCommentaryBook': 'CommentaryBook',
+  'ApiCommentaryBookChapter': 'CommentaryBookChapter',
+  'ApiCommentaryProfile': 'CommentaryProfileRef',
+  'ApiCommentaryProfileContent': 'CommentaryProfileContent',
+  'ApiDataset': 'Dataset',
+  'ApiDatasetBook': 'DatasetBook',
+  'ApiDatasetBookChapter': 'DatasetBookChapter',
+  'ChapterData': 'Chapter',
+  'CommentaryChapterData': 'CommentaryChapter',
+  'TranslationBookChapterAudioLinks': 'AudioLinks',
+  'DatasetChapterData': 'DatasetChapterData',
+  'DatasetChapterVerseContent': 'DatasetChapterVerseContent',
+  'ScoredVerseRef': 'CrossReference',
+  'CommentaryProfile': 'CommentaryProfile',
+};
+
+function renameRef(ref) {
+  const name = ref.replace('#/components/schemas/', '');
+  const renamed = SCHEMA_RENAMES[name] || name;
+  return `#/components/schemas/${renamed}`;
+}
+
+/** Recursively rename $ref values in a schema. */
+function renameRefs(schema) {
+  if (!schema || typeof schema !== 'object') return schema;
+  if (Array.isArray(schema)) return schema.map(renameRefs);
+  const result = {};
+  for (const [k, v] of Object.entries(schema)) {
+    if (k === '$ref' && typeof v === 'string') {
+      result[k] = renameRef(v);
+    } else {
+      result[k] = renameRefs(v);
+    }
+  }
+  return result;
+}
+
+// Build renamed schemas
+const renamedSchemas = {};
+for (const [origName, schema] of Object.entries(schemas)) {
+  const newName = SCHEMA_RENAMES[origName] || origName;
+  renamedSchemas[newName] = renameRefs(schema);
+}
+
+// Add discriminator to ChapterContent if present
+if (renamedSchemas['ChapterContent']) {
+  renamedSchemas['ChapterContent'].discriminator = {
+    propertyName: 'type',
+    mapping: {
+      verse: '#/components/schemas/ChapterVerse',
+      heading: '#/components/schemas/ChapterHeading',
+      line_break: '#/components/schemas/ChapterLineBreak',
+      hebrew_subtitle: '#/components/schemas/ChapterHebrewSubtitle',
+    },
+  };
+}
+
+// Fix AudioLinks — should be additionalProperties map, not regular properties
+renamedSchemas['AudioLinks'] = {
+  type: 'object',
+  description: 'Map of reader name to audio file URL',
+  additionalProperties: { type: 'string', format: 'uri' },
+};
+
+// Add VerseContentItem union schema
+renamedSchemas['VerseContentItem'] = {
+  description: 'A single element within verse content',
+  oneOf: [
+    { type: 'string' },
+    { $ref: '#/components/schemas/FormattedText' },
+    { $ref: '#/components/schemas/VerseFootnoteReference' },
+    { $ref: '#/components/schemas/InlineHeading' },
+    { $ref: '#/components/schemas/InlineLineBreak' },
+  ],
+};
+
+// Fix ChapterVerse content items to reference VerseContentItem
+if (renamedSchemas['ChapterVerse'] && renamedSchemas['ChapterVerse'].properties &&
+    renamedSchemas['ChapterVerse'].properties.content) {
+  renamedSchemas['ChapterVerse'].properties.content = {
+    type: 'array',
+    items: { $ref: '#/components/schemas/VerseContentItem' },
+  };
+}
+
+// Fix ChapterHebrewSubtitle content items
+if (renamedSchemas['ChapterHebrewSubtitle'] && renamedSchemas['ChapterHebrewSubtitle'].properties &&
+    renamedSchemas['ChapterHebrewSubtitle'].properties.content) {
+  renamedSchemas['ChapterHebrewSubtitle'].properties.content = {
+    type: 'array',
+    items: {
+      oneOf: [
+        { type: 'string' },
+        { $ref: '#/components/schemas/FormattedText' },
+        { $ref: '#/components/schemas/VerseFootnoteReference' },
+      ],
+    },
+  };
+}
+
+// Fix Chapter content to reference ChapterContent
+if (renamedSchemas['Chapter'] && renamedSchemas['Chapter'].properties &&
+    renamedSchemas['Chapter'].properties.content) {
+  renamedSchemas['Chapter'].properties.content = {
+    type: 'array',
+    items: { $ref: '#/components/schemas/ChapterContent' },
+  };
+}
+
+// Fix CommentaryChapter content
+if (renamedSchemas['CommentaryChapter'] && renamedSchemas['CommentaryChapter'].properties &&
+    renamedSchemas['CommentaryChapter'].properties.content) {
+  renamedSchemas['CommentaryChapter'].properties.content = {
+    type: 'array',
+    items: { $ref: '#/components/schemas/ChapterVerse' },
+  };
+}
+
+// Fix ChapterHeading content — should be array of strings
+if (renamedSchemas['ChapterHeading'] && renamedSchemas['ChapterHeading'].properties &&
+    renamedSchemas['ChapterHeading'].properties.content) {
+  renamedSchemas['ChapterHeading'].properties.content = {
+    type: 'array',
+    items: { type: 'string' },
+    description: 'Heading text segments; concatenate with a space',
+  };
+}
+
+// Fix CrossReference — add book field (from VerseRef parent which is imported externally)
+if (renamedSchemas['CrossReference']) {
+  renamedSchemas['CrossReference'] = {
+    type: 'object',
+    required: ['book', 'chapter', 'verse', 'score'],
+    properties: {
+      book: { type: 'string', description: 'USFM book identifier' },
+      chapter: { type: 'integer', description: 'Chapter number' },
+      verse: { type: 'integer', description: 'Verse number' },
+      score: { type: 'number', description: 'Relevance score' },
+    },
+  };
+}
+
+// Fix CommentaryProfile — reference field is VerseRef which is external
+if (renamedSchemas['CommentaryProfile']) {
+  if (renamedSchemas['CommentaryProfile'].properties &&
+      renamedSchemas['CommentaryProfile'].properties.reference) {
+    renamedSchemas['CommentaryProfile'].properties.reference = {
+      oneOf: [
+        {
+          type: 'object',
+          required: ['book', 'chapter', 'verse'],
+          properties: {
+            book: { type: 'string' },
+            chapter: { type: 'integer' },
+            verse: { type: 'integer' },
+          },
+        },
+        { type: 'null' },
+      ],
+    };
+  }
+}
+
+// Fix CommentaryProfileRef — inherit from CommentaryProfile + add links
+if (renamedSchemas['CommentaryProfileRef']) {
+  renamedSchemas['CommentaryProfileRef'] = {
+    type: 'object',
+    required: ['id', 'subject', 'thisProfileLink'],
+    properties: {
+      id: { type: 'string' },
+      subject: { type: 'string' },
+      reference: {
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              book: { type: 'string' },
+              chapter: { type: 'integer' },
+              verse: { type: 'integer' },
+            },
+          },
+          { type: 'null' },
+        ],
+      },
+      thisProfileLink: { type: 'string' },
+      referenceChapterLink: { type: ['string', 'null'] },
+    },
+  };
+}
+
+// Build the parameters
+const parameters = {
+  translationId: {
+    name: 'translationId',
+    in: 'path',
+    required: true,
+    description: 'Translation identifier (e.g. BSB, KJV)',
+    schema: { type: 'string' },
+  },
+  bookId: {
+    name: 'bookId',
+    in: 'path',
+    required: true,
+    description: 'USFM book identifier (e.g. GEN, JHN, REV)',
+    schema: { type: 'string' },
+  },
+  chapter: {
+    name: 'chapter',
+    in: 'path',
+    required: true,
+    description: 'Chapter number',
+    schema: { type: 'integer', minimum: 1 },
+  },
+  commentaryId: {
+    name: 'commentaryId',
+    in: 'path',
+    required: true,
+    description: 'Commentary identifier',
+    schema: { type: 'string' },
+  },
+  datasetId: {
+    name: 'datasetId',
+    in: 'path',
+    required: true,
+    description: 'Dataset identifier',
+    schema: { type: 'string' },
+  },
+  profileId: {
+    name: 'profileId',
+    in: 'path',
+    required: true,
+    description: 'Profile identifier',
+    schema: { type: 'string' },
+  },
+};
+
+// Build the paths from the endpoint patterns in api.ts
+const paths = {
+  '/api/available_translations.json': {
+    get: {
+      operationId: 'listTranslations',
+      summary: 'List all available translations',
+      responses: {
+        '200': {
+          description: 'List of translations',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['translations'],
+                properties: {
+                  translations: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/Translation' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/{translationId}/books.json': {
+    get: {
+      operationId: 'listBooks',
+      summary: 'List books for a translation',
+      parameters: [{ $ref: '#/components/parameters/translationId' }],
+      responses: {
+        '200': {
+          description: 'Translation info and list of books',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['translation', 'books'],
+                properties: {
+                  translation: { $ref: '#/components/schemas/Translation' },
+                  books: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/TranslationBook' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/{translationId}/{bookId}/{chapter}.json': {
+    get: {
+      operationId: 'getChapter',
+      summary: 'Get chapter content',
+      parameters: [
+        { $ref: '#/components/parameters/translationId' },
+        { $ref: '#/components/parameters/bookId' },
+        { $ref: '#/components/parameters/chapter' },
+      ],
+      responses: {
+        '200': {
+          description: 'Chapter content with navigation links',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ChapterResponse' },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/{translationId}/complete.json': {
+    get: {
+      operationId: 'getCompleteTranslation',
+      summary: 'Get complete translation download',
+      parameters: [{ $ref: '#/components/parameters/translationId' }],
+      responses: {
+        '200': {
+          description: 'Complete translation with all books and chapters',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/TranslationComplete' },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/available_commentaries.json': {
+    get: {
+      operationId: 'listCommentaries',
+      summary: 'List all available commentaries',
+      responses: {
+        '200': {
+          description: 'List of commentaries',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['commentaries'],
+                properties: {
+                  commentaries: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/Commentary' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/c/{commentaryId}/books.json': {
+    get: {
+      operationId: 'listCommentaryBooks',
+      summary: 'List books for a commentary',
+      parameters: [{ $ref: '#/components/parameters/commentaryId' }],
+      responses: {
+        '200': {
+          description: 'Commentary info and list of books',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['commentary', 'books'],
+                properties: {
+                  commentary: { $ref: '#/components/schemas/Commentary' },
+                  books: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/CommentaryBook' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/c/{commentaryId}/{bookId}/{chapter}.json': {
+    get: {
+      operationId: 'getCommentaryChapter',
+      summary: 'Get commentary chapter content',
+      parameters: [
+        { $ref: '#/components/parameters/commentaryId' },
+        { $ref: '#/components/parameters/bookId' },
+        { $ref: '#/components/parameters/chapter' },
+      ],
+      responses: {
+        '200': {
+          description: 'Commentary chapter content with navigation links',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/CommentaryBookChapter' },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/c/{commentaryId}/profiles.json': {
+    get: {
+      operationId: 'listCommentaryProfiles',
+      summary: 'List profiles for a commentary',
+      parameters: [{ $ref: '#/components/parameters/commentaryId' }],
+      responses: {
+        '200': {
+          description: 'Commentary info and list of profiles',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['commentary', 'profiles'],
+                properties: {
+                  commentary: { $ref: '#/components/schemas/Commentary' },
+                  profiles: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/CommentaryProfileRef' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/c/{commentaryId}/profiles/{profileId}.json': {
+    get: {
+      operationId: 'getCommentaryProfile',
+      summary: 'Get commentary profile content',
+      parameters: [
+        { $ref: '#/components/parameters/commentaryId' },
+        { $ref: '#/components/parameters/profileId' },
+      ],
+      responses: {
+        '200': {
+          description: 'Commentary profile content',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/CommentaryProfileContent' },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/available_datasets.json': {
+    get: {
+      operationId: 'listDatasets',
+      summary: 'List all available datasets',
+      responses: {
+        '200': {
+          description: 'List of datasets',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['datasets'],
+                properties: {
+                  datasets: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/Dataset' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/d/{datasetId}/books.json': {
+    get: {
+      operationId: 'listDatasetBooks',
+      summary: 'List books for a dataset',
+      parameters: [{ $ref: '#/components/parameters/datasetId' }],
+      responses: {
+        '200': {
+          description: 'Dataset info and list of books',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['dataset', 'books'],
+                properties: {
+                  dataset: { $ref: '#/components/schemas/Dataset' },
+                  books: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/DatasetBook' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/d/{datasetId}/{bookId}/{chapter}.json': {
+    get: {
+      operationId: 'getDatasetChapter',
+      summary: 'Get dataset chapter content (cross-references)',
+      parameters: [
+        { $ref: '#/components/parameters/datasetId' },
+        { $ref: '#/components/parameters/bookId' },
+        { $ref: '#/components/parameters/chapter' },
+      ],
+      responses: {
+        '200': {
+          description: 'Dataset chapter content with cross-references',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/DatasetBookChapter' },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// Assemble the full OpenAPI document
+const spec = {
+  openapi: '3.1.0',
+  info: {
+    title: 'helloao.org Bible API',
+    version: API_VERSION,
+    description: 'Public, read-only JSON API serving Bible translations, books, and chapter content from helloao.org. No authentication required.',
+    license: {
+      name: 'Various (per translation)',
+      url: 'https://helloao.org',
+    },
+    'x-api-source': 'https://bible.helloao.org',
+    'x-api-changelog': 'https://github.com/HelloAOLab/bible-api/blob/main/API-CHANGELOG.md',
+  },
+  servers: [
+    { url: 'https://bible.helloao.org', description: 'Production' },
+  ],
+  paths,
+  components: {
+    parameters,
+    schemas: renamedSchemas,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 7. Output
+// ---------------------------------------------------------------------------
+if (process.argv.includes('--json')) {
+  process.stdout.write(JSON.stringify(spec, null, 2) + '\n');
+} else {
+  process.stdout.write(toYaml(spec, 0) + '\n');
+}

--- a/scripts/generated_client/__init__.py
+++ b/scripts/generated_client/__init__.py
@@ -1,0 +1,6 @@
+"""Auto-generated Python client for the helloao.org Bible API."""
+
+from .client import APIError, BibleAPIClient, _from_dict
+from .models import *
+
+__all__ = ["APIError", "BibleAPIClient"] + ['Translation', 'TranslationBook', 'ChapterResponse', 'TranslationComplete', 'TranslationCompleteBook', 'Commentary', 'CommentaryBook', 'CommentaryBookChapter', 'CommentaryProfileRef', 'CommentaryProfileContent', 'Dataset', 'DatasetBook', 'DatasetBookChapter', 'Chapter', 'CommentaryChapter', 'ChapterHeading', 'ChapterLineBreak', 'ChapterVerse', 'ChapterHebrewSubtitle', 'FormattedText', 'InlineHeading', 'InlineLineBreak', 'VerseFootnoteReference', 'ChapterFootnote', 'DatasetChapterData', 'DatasetChapterVerseContent', 'CrossReference', 'CommentaryProfile']

--- a/scripts/generated_client/client.py
+++ b/scripts/generated_client/client.py
@@ -1,0 +1,130 @@
+"""Auto-generated API client from OpenAPI spec."""
+from __future__ import annotations
+
+import json
+import urllib.request
+import urllib.error
+from typing import Any, Dict, List, Optional
+
+from .models import *
+
+
+class APIError(Exception):
+    """Raised when an API request fails."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _from_dict(cls, data):
+    """Recursively construct a dataclass from a dict."""
+    if data is None or not isinstance(data, dict):
+        return data
+    import dataclasses
+    if not dataclasses.is_dataclass(cls):
+        return data
+    field_map = {}
+    for f in dataclasses.fields(cls):
+        # Check the comment for the original json key name
+        field_map[f.name] = f
+    kwargs = {}
+    # Build reverse map: json_key -> field
+    json_to_field = {}
+    for f in dataclasses.fields(cls):
+        if f.metadata and "json_key" in f.metadata:
+            json_to_field[f.metadata["json_key"]] = f
+        json_to_field[f.name] = f
+    for key, val in data.items():
+        snake = key
+        # Try camelCase -> snake_case
+        import re
+        s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", key)
+        snake = re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+        if snake in field_map:
+            kwargs[snake] = val
+        elif key in field_map:
+            kwargs[key] = val
+    return cls(**kwargs)
+
+
+class BibleAPIClient:
+    """Auto-generated client for the helloao.org Bible API."""
+
+    DEFAULT_BASE_URL = "https://bible.helloao.org"
+
+    def __init__(self, base_url: Optional[str] = None, timeout: int = 30):
+        self.base_url = (base_url or self.DEFAULT_BASE_URL).rstrip("/")
+        self.timeout = timeout
+
+    def _request(self, path: str) -> Any:
+        """Make a GET request and return parsed JSON."""
+        url = self.base_url + path
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            raise APIError(f"HTTP {e.code}: {e.reason}", e.code) from e
+        except urllib.error.URLError as e:
+            raise APIError(f"Connection error: {e.reason}") from e
+
+    def list_translations(self) -> Dict[str, Any]:
+        """List all available translations"""
+        path = "/api/available_translations.json"
+        return self._request(path)
+
+    def list_books(self, translation_id: str) -> Dict[str, Any]:
+        """List books for a translation"""
+        path = f"/api/{translation_id}/books.json"
+        return self._request(path)
+
+    def get_chapter(self, translation_id: str, book_id: str, chapter: int) -> ChapterResponse:
+        """Get chapter content"""
+        path = f"/api/{translation_id}/{book_id}/{chapter}.json"
+        return _from_dict(ChapterResponse, self._request(path))
+
+    def get_complete_translation(self, translation_id: str) -> TranslationComplete:
+        """Get complete translation download"""
+        path = f"/api/{translation_id}/complete.json"
+        return _from_dict(TranslationComplete, self._request(path))
+
+    def list_commentaries(self) -> Dict[str, Any]:
+        """List all available commentaries"""
+        path = "/api/available_commentaries.json"
+        return self._request(path)
+
+    def list_commentary_books(self, commentary_id: str) -> Dict[str, Any]:
+        """List books for a commentary"""
+        path = f"/api/c/{commentary_id}/books.json"
+        return self._request(path)
+
+    def get_commentary_chapter(self, commentary_id: str, book_id: str, chapter: int) -> CommentaryBookChapter:
+        """Get commentary chapter content"""
+        path = f"/api/c/{commentary_id}/{book_id}/{chapter}.json"
+        return _from_dict(CommentaryBookChapter, self._request(path))
+
+    def list_commentary_profiles(self, commentary_id: str) -> Dict[str, Any]:
+        """List profiles for a commentary"""
+        path = f"/api/c/{commentary_id}/profiles.json"
+        return self._request(path)
+
+    def get_commentary_profile(self, commentary_id: str, profile_id: str) -> CommentaryProfileContent:
+        """Get commentary profile content"""
+        path = f"/api/c/{commentary_id}/profiles/{profile_id}.json"
+        return _from_dict(CommentaryProfileContent, self._request(path))
+
+    def list_datasets(self) -> Dict[str, Any]:
+        """List all available datasets"""
+        path = "/api/available_datasets.json"
+        return self._request(path)
+
+    def list_dataset_books(self, dataset_id: str) -> Dict[str, Any]:
+        """List books for a dataset"""
+        path = f"/api/d/{dataset_id}/books.json"
+        return self._request(path)
+
+    def get_dataset_chapter(self, dataset_id: str, book_id: str, chapter: int) -> DatasetBookChapter:
+        """Get dataset chapter content (cross-references)"""
+        path = f"/api/d/{dataset_id}/{book_id}/{chapter}.json"
+        return _from_dict(DatasetBookChapter, self._request(path))

--- a/scripts/generated_client/models.py
+++ b/scripts/generated_client/models.py
@@ -1,0 +1,290 @@
+"""Auto-generated dataclass models from OpenAPI spec."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+
+@dataclass
+class Translation:
+    id: str
+    name: str
+    website: str
+    license_url: str  # json: licenseUrl
+    english_name: str  # json: englishName
+    language: str
+    text_direction: str  # json: textDirection
+    list_of_books_api_link: str  # json: listOfBooksApiLink
+    available_formats: List[str]  # json: availableFormats
+    number_of_books: int  # json: numberOfBooks
+    total_number_of_chapters: int  # json: totalNumberOfChapters
+    total_number_of_verses: int  # json: totalNumberOfVerses
+    license_notes: Optional[str] = None  # json: licenseNotes
+    license_notice: Optional[str] = None  # json: licenseNotice
+    short_name: Optional[str] = None  # json: shortName
+    number_of_apocryphal_books: Optional[int] = None  # json: numberOfApocryphalBooks
+    total_number_of_apocryphal_chapters: Optional[int] = None  # json: totalNumberOfApocryphalChapters
+    total_number_of_apocryphal_verses: Optional[int] = None  # json: totalNumberOfApocryphalVerses
+    language_name: Optional[str] = None  # json: languageName
+    language_english_name: Optional[str] = None  # json: languageEnglishName
+    complete_translation_api_link: Optional[str] = None  # json: completeTranslationApiLink
+
+
+@dataclass
+class TranslationBook:
+    id: str
+    name: str
+    common_name: str  # json: commonName
+    title: Optional[str]
+    order: int
+    first_chapter_number: int  # json: firstChapterNumber
+    first_chapter_api_link: str  # json: firstChapterApiLink
+    last_chapter_number: int  # json: lastChapterNumber
+    last_chapter_api_link: str  # json: lastChapterApiLink
+    number_of_chapters: int  # json: numberOfChapters
+    total_number_of_verses: int  # json: totalNumberOfVerses
+    is_apocryphal: Optional[bool] = None  # json: isApocryphal
+
+
+@dataclass
+class ChapterResponse:
+    chapter: Chapter
+    this_chapter_audio_links: AudioLinks  # json: thisChapterAudioLinks
+    translation: Translation
+    book: TranslationBook
+    this_chapter_link: str  # json: thisChapterLink
+    next_chapter_api_link: Optional[str]  # json: nextChapterApiLink
+    next_chapter_audio_links: Optional[AudioLinks]  # json: nextChapterAudioLinks
+    previous_chapter_api_link: Optional[str]  # json: previousChapterApiLink
+    previous_chapter_audio_links: Optional[AudioLinks]  # json: previousChapterAudioLinks
+    number_of_verses: int  # json: numberOfVerses
+
+
+@dataclass
+class TranslationComplete:
+    translation: Translation
+    books: List[TranslationCompleteBook]
+
+
+@dataclass
+class TranslationCompleteBook:
+    id: str
+    name: str
+    common_name: str  # json: commonName
+    title: Optional[str]
+    order: int
+    number_of_chapters: int  # json: numberOfChapters
+    total_number_of_verses: int  # json: totalNumberOfVerses
+    chapters: List[TranslationBookChapter]
+    is_apocryphal: Optional[bool] = None  # json: isApocryphal
+
+
+@dataclass
+class Commentary:
+    id: str
+    name: str
+    website: str
+    license_url: str  # json: licenseUrl
+    english_name: str  # json: englishName
+    language: str
+    text_direction: str  # json: textDirection
+    list_of_books_api_link: str  # json: listOfBooksApiLink
+    list_of_profiles_api_link: str  # json: listOfProfilesApiLink
+    available_formats: List[str]  # json: availableFormats
+    number_of_books: int  # json: numberOfBooks
+    total_number_of_chapters: int  # json: totalNumberOfChapters
+    total_number_of_verses: int  # json: totalNumberOfVerses
+    total_number_of_profiles: int  # json: totalNumberOfProfiles
+    license_notes: Optional[str] = None  # json: licenseNotes
+    language_name: Optional[str] = None  # json: languageName
+    language_english_name: Optional[str] = None  # json: languageEnglishName
+
+
+@dataclass
+class CommentaryBook:
+    id: str
+    name: str
+    common_name: str  # json: commonName
+    order: int
+    first_chapter_number: Optional[int]  # json: firstChapterNumber
+    first_chapter_api_link: Optional[str]  # json: firstChapterApiLink
+    last_chapter_number: Optional[int]  # json: lastChapterNumber
+    last_chapter_api_link: Optional[str]  # json: lastChapterApiLink
+    number_of_chapters: int  # json: numberOfChapters
+    total_number_of_verses: int  # json: totalNumberOfVerses
+    introduction: Optional[str] = None
+    introduction_summary: Optional[str] = None  # json: introductionSummary
+
+
+@dataclass
+class CommentaryBookChapter:
+    chapter: CommentaryChapter
+    commentary: Commentary
+    book: CommentaryBook
+    this_chapter_link: str  # json: thisChapterLink
+    next_chapter_api_link: Optional[str]  # json: nextChapterApiLink
+    previous_chapter_api_link: Optional[str]  # json: previousChapterApiLink
+    number_of_verses: int  # json: numberOfVerses
+
+
+@dataclass
+class CommentaryProfileRef:
+    id: str
+    subject: str
+    this_profile_link: str  # json: thisProfileLink
+    reference: Optional[Dict[str, Any]] = None
+    reference_chapter_link: Optional[str] = None  # json: referenceChapterLink
+
+
+@dataclass
+class CommentaryProfileContent:
+    commentary: Commentary
+    profile: CommentaryProfileRef
+    content: List[str]
+
+
+@dataclass
+class Dataset:
+    id: str
+    name: str
+    website: str
+    license_url: str  # json: licenseUrl
+    english_name: str  # json: englishName
+    language: str
+    text_direction: str  # json: textDirection
+    list_of_books_api_link: str  # json: listOfBooksApiLink
+    available_formats: List[str]  # json: availableFormats
+    number_of_books: int  # json: numberOfBooks
+    total_number_of_chapters: int  # json: totalNumberOfChapters
+    total_number_of_verses: int  # json: totalNumberOfVerses
+    total_number_of_references: int  # json: totalNumberOfReferences
+    license_notes: Optional[str] = None  # json: licenseNotes
+    language_name: Optional[str] = None  # json: languageName
+    language_english_name: Optional[str] = None  # json: languageEnglishName
+
+
+@dataclass
+class DatasetBook:
+    id: str
+    order: int
+    first_chapter_number: int  # json: firstChapterNumber
+    first_chapter_api_link: str  # json: firstChapterApiLink
+    last_chapter_number: int  # json: lastChapterNumber
+    last_chapter_api_link: str  # json: lastChapterApiLink
+    number_of_chapters: int  # json: numberOfChapters
+    total_number_of_verses: int  # json: totalNumberOfVerses
+    total_number_of_references: int  # json: totalNumberOfReferences
+
+
+@dataclass
+class DatasetBookChapter:
+    chapter: DatasetChapterData
+    dataset: Dataset
+    book: DatasetBook
+    this_chapter_link: str  # json: thisChapterLink
+    next_chapter_api_link: Optional[str]  # json: nextChapterApiLink
+    previous_chapter_api_link: Optional[str]  # json: previousChapterApiLink
+    number_of_verses: int  # json: numberOfVerses
+    number_of_references: int  # json: numberOfReferences
+
+
+@dataclass
+class Chapter:
+    number: int
+    content: List[ChapterContent]
+    footnotes: List[ChapterFootnote]
+
+
+@dataclass
+class CommentaryChapter:
+    number: int
+    content: List[ChapterVerse]
+    introduction: Optional[str] = None
+
+
+@dataclass
+class ChapterHeading:
+    type: str
+    content: List[str]
+
+
+@dataclass
+class ChapterLineBreak:
+    type: str
+
+
+@dataclass
+class ChapterVerse:
+    type: str
+    number: int
+    content: List[VerseContentItem]
+
+
+@dataclass
+class ChapterHebrewSubtitle:
+    type: str
+    content: List[Union[str, FormattedText, VerseFootnoteReference]]
+
+
+@dataclass
+class FormattedText:
+    text: str
+    poem: Optional[int] = None
+    words_of_jesus: Optional[bool] = None  # json: wordsOfJesus
+
+
+@dataclass
+class InlineHeading:
+    heading: str
+
+
+@dataclass
+class InlineLineBreak:
+    line_break: bool  # json: lineBreak
+
+
+@dataclass
+class VerseFootnoteReference:
+    note_id: int  # json: noteId
+
+
+@dataclass
+class ChapterFootnote:
+    note_id: int  # json: noteId
+    text: str
+    caller: Union[str, str]
+    reference: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class DatasetChapterData:
+    number: int
+    content: List[DatasetChapterVerseContent]
+
+
+@dataclass
+class DatasetChapterVerseContent:
+    verse: int
+    references: List[CrossReference]
+
+
+@dataclass
+class CrossReference:
+    book: str
+    chapter: int
+    verse: int
+    score: float
+
+
+@dataclass
+class CommentaryProfile:
+    id: str
+    subject: str
+    reference: Optional[Dict[str, Any]]
+
+
+
+# Type aliases (must be after class definitions)
+ChapterContent = Union[ChapterHeading, ChapterLineBreak, ChapterVerse, ChapterHebrewSubtitle]
+AudioLinks = Dict[str, str]
+VerseContentItem = Union[str, FormattedText, VerseFootnoteReference, InlineHeading, InlineLineBreak]

--- a/vendor/API-CHANGELOG.md
+++ b/vendor/API-CHANGELOG.md
@@ -1,0 +1,139 @@
+# API Changelog
+
+This is the log of changes for the Free Use Bible API.
+For information on the API Generator, see [GENERATOR-CHANGELOG.md](./GENERATOR-CHANGELOG.md).
+
+## V1.11.0
+
+#### Date: 2026-03-24
+
+### :rocket: Features
+
+-   Changed the common name of Song of Solomon in English from "Song of Songs" to "Song of Solomon".
+
+## V1.10.0
+
+#### Date: 2026-02-20
+
+### :rocket: Features
+
+-   Updated the `BSB` translation to 2025-12-23 (Third Printing)
+-   Added Garth's Hyper-literal Translation (`GHT`) and Greek sources (`GHTG`).
+
+## V1.9.1
+
+#### Date: 2026-02-18
+
+### :boom: Breaking Changes
+
+-   Changed the following translation IDs to match their language codes:
+    -   `cug_wbt` -> `cnq_wbt`
+    -   `plj_tsc` -> `zlu_tsc`
+
+### :bug: Bug Fixes
+
+-   Updated language codes for the `cnq_wbt` (formerly `cug_wbt`) and `zlu_tsc` (formerly `plj_tsc`) translations.
+    -   `cug` (Chungmboko langauge group) -> `cnq` (Chung language) ([Change Request](https://iso639-3.sil.org/request/2021-012))
+    -   `plj` (Polci langauge group) -> `zlu` (Zul language) ([Change Request](https://iso639-3.sil.org/request/2022-023))
+
+## V1.9.0
+
+#### Date: 2026-01-12
+
+### :rocket: Features
+
+-   Added endpoints for getting an entire translation. ([#37](https://github.com/HelloAOLab/bible-api/pull/37))
+
+## V1.7.0
+
+#### Date: 2025-10-28
+
+### :rocket: Features
+
+-   Added the [Open BIble Cross Reference](https://www.openbible.info/labs/cross-references/) dataset.
+
+## V1.6.0
+
+#### Date: 2025-09-16
+
+### :rocket: Features
+
+-   Added the `firstChapterNumber` and `lastChapterNumber` fields for `TranslationBook`.
+
+### :bug: Bug Fixes
+
+-   Fixed chapter links to start at the correct number for the book. ([#24](https://github.com/HelloAOLab/bible-api/issues/24))
+
+## V1.5.0
+
+#### Date: 2025-07-02
+
+### :rocket: Features
+
+-   Switched primary source for Bible translations to [ebible.org](https://ebible.org/).
+    -   This switch adds a bunch of new translations in various different languages.
+-   Added apocrypha for translations which decide to include them.
+    -   Apocryphal books have their `isApocryphal` property set to `true` in their book information and are always ordered after Revelation.
+    -   An example is the King James Version + Apocrypha (`eng_kja`) translation.
+
+### :bug: Bug Fixes
+
+-   Fixed missing verses in PSA 119 in the `npi_ulb` translation. ([#18](https://github.com/HelloAOLab/bible-api/issues/18))
+-   Fixed missing books in the `fra_lsg` translation. ([#17](https://github.com/HelloAOLab/bible-api/issues/17))
+-   Fixed missing books in the `hbo_wlc` translation. ([#14](https://github.com/HelloAOLab/bible-api/issues/14))
+-   Changed the ID of `eng_drv` to `eng_dra`. ([#21](https://github.com/HelloAOLab/bible-api/issues/21))
+-   Fixed audio links for Titus in the BSB translation. ([#15](https://github.com/HelloAOLab/bible-api/issues/15))
+
+## V1.4.0
+
+#### Date: 2024-12-18
+
+### :rocket: Features
+
+-   Added the [Tyndale](https://tyndaleopenresources.com/) Bible commentary.
+
+### :bug: Bug Fixes
+
+-   Fixed cases where consecutive poem lines that have the same indentation now have an explicit line break to indicate that they are actually on separate lines.
+
+## V1.3.0
+
+#### Date: 2024-11-15
+
+### :rocket: Features
+
+-   Added support for Bible commentaries.
+    -   See the the [API Reference](https://bible.helloao.org/docs/reference/#available-commentaries) for more info.
+
+## V1.2.0
+
+#### Date: 2024-07-25
+
+### :rocket: Features
+
+-   Added the total number of books, chapters, and verses that each translation, book, and chapter contains.
+-   Added `languageName` and `languageEnglishName` for translations so that it is easy to display a name for the language that the translation is in.
+
+### :bug: Bug Fixes
+
+-   Fixed an issue where parts of some verses were missing.
+-   Fixed the documentation to note that the language of a translation is in ISO 639 format.
+
+## V1.1.0
+
+#### Date: 2024-07-11
+
+### :rocket: Features
+
+-   Added links for audio versions to the chapter data.
+    -   Currently, this is only available for the BSB translation.
+    -   Thanks to [https://openbible.com/](https://openbible.com/) for making this possible!
+
+## V1.0.0
+
+#### Date: 2024-07-11
+
+### :bug: Bug Fixes
+
+-   Fixed an issue where where some chapters would be missing the first verse of the chapter.
+    -   This was fixed by moving to using USX versions of translations.

--- a/vendor/api.ts
+++ b/vendor/api.ts
@@ -1,0 +1,1629 @@
+import {
+    ChapterContent,
+    ChapterData,
+    ChapterFootnote,
+    Commentary,
+    CommentaryBook,
+    CommentaryBookChapter,
+    CommentaryProfile,
+    Dataset,
+    DatasetBook,
+    DatasetBookChapter,
+    OutputFile,
+    Translation,
+    TranslationBook,
+    TranslationBookChapter,
+    TranslationBookChapterAudioLinks,
+} from './common-types.js';
+import { DatasetOutput } from './dataset.js';
+
+/**
+ * Defines the output of the API generation.
+ */
+export interface ApiOutput {
+    /**
+     * The list of available translations.
+     * This maps to the /api/available-translations.json endpoint.
+     */
+    availableTranslations: ApiAvailableTranslations;
+
+    /**
+     * The list of books for each translation.
+     * This maps to the /api/:translationId/books.json endpoint.
+     */
+    translationBooks: ApiTranslationBooks[];
+
+    /**
+     * The list of chapters for each book.
+     * This maps to the following endpoints:
+     * - /api/:translationId/:bookId/:chapterNumber.json
+     * - /api/:translationId/:bookCommonName/:chapterNumber.json
+     */
+    translationBookChapters: ApiTranslationBookChapter[];
+
+    /**
+     * The list of audio files.
+     * This maps to the following endpoints:
+     * - /api/:translationId/:bookId/:chapterNumber.:reader.mp3
+     */
+    translationBookChapterAudio: ApiTranslationBookChapterAudio[];
+
+    /**
+     * The list of available commentaries.
+     * This maps to the /api/available-commentaries.json endpoint.
+     */
+    availableCommentaries: ApiAvailableCommentaries;
+
+    /**
+     * The list of books for each commentary.
+     * This maps to the /api/c/:commentaryId/books.json endpoint.
+     */
+    commentaryBooks: ApiCommentaryBooks[];
+
+    /**
+     * The list of profiles for each commentary.
+     * This maps to the /api/c/:commentaryId/profiles.json endpoint.
+     */
+    commentaryProfiles: ApiCommentaryProfiles[];
+
+    /**
+     * The list of chapters for each commentary book.
+     * This maps to the following endpoint:
+     * - /api/c/:commentaryId/:bookId/:chapterNumber.json
+     */
+    commentaryBookChapters: ApiCommentaryBookChapter[];
+
+    /**
+     * The list of individual profiles for each commentary.
+     * This maps to the following endpoint:
+     * - /api/c/:commentaryId/profiles/:profileId.json
+     */
+    commentaryProfileContents: ApiCommentaryProfileContent[];
+
+    /**
+     * The list of available datasets.
+     * This maps to the /api/available-datasets.json endpoint.
+     */
+    availableDatasets?: ApiAvailableDatasets;
+
+    /**
+     * The list of books for each dataset.
+     * This maps to the /api/d/:datasetId/books.json endpoint.
+     */
+    datasetBooks?: ApiDatasetBooks[];
+
+    /**
+     * The list of chapters for each dataset book.
+     * This maps to the following endpoint:
+     * - /api/d/:datasetId/:bookId/:chapterNumber.json
+     */
+    datasetBookChapters?: ApiDatasetBookChapter[];
+
+    /**
+     * The complete translation data for each translation.
+     * This maps to the /api/:translationId/complete.json endpoint.
+     */
+    translationComplete: ApiTranslationComplete[];
+
+    /**
+     * The path prefix that the API should use.
+     */
+    pathPrefix: string;
+}
+
+/**
+ * The list of available translations.
+ * Maps to the /api/available-translations.json endpoint.
+ */
+export interface ApiAvailableTranslations {
+    /**
+     * The list of translations.
+     */
+    translations: ApiTranslation[];
+}
+
+/**
+ * The list of available commentaries.
+ * Maps to the /api/available-commentaries.json endpoint.
+ */
+export interface ApiAvailableCommentaries {
+    /**
+     * The list of commentaries.
+     */
+    commentaries: ApiCommentary[];
+}
+
+/**
+ * The list of available datasets.
+ * Maps to the /api/available-datasets.json endpoint.
+ */
+export interface ApiAvailableDatasets {
+    datasets: ApiDataset[];
+}
+
+/**
+ * Defines a dataset that is used in the API.
+ */
+export interface ApiDataset extends Dataset {
+    /**
+     * The API link for the list of books for this dataset.
+     */
+    listOfBooksApiLink: string;
+
+    /**
+     * The available list of formats.
+     */
+    availableFormats: 'json'[];
+
+    /**
+     * The number of books that are contained in this dataset.
+     */
+    numberOfBooks: number;
+
+    /**
+     * The total number of chapters that are contained in this dataset.
+     */
+    totalNumberOfChapters: number;
+
+    /**
+     * The total number of verses that are contained in this dataset.
+     */
+    totalNumberOfVerses: number;
+
+    /**
+     * The total number of references that are contained in this dataset.
+     */
+    totalNumberOfReferences: number;
+
+    /**
+     * Gets the name of the language that the commentary is in.
+     * Null or undefined if the name of the language is not known.
+     */
+    languageName?: string;
+
+    /**
+     * Gets the name of the language in English.
+     * Null or undefined if the language doesn't have an english name.
+     */
+    languageEnglishName?: string;
+}
+
+/**
+ * Defines a translation that is used in the API.
+ */
+export interface ApiTranslation extends Translation {
+    /**
+     * The API link for the list of available books for this translation.
+     */
+    listOfBooksApiLink: string;
+
+    /**
+     * The available list of formats.
+     */
+    availableFormats: ('json' | 'usfm')[];
+
+    /**
+     * The number of books that are contained in this translation.
+     *
+     * Complete translations should have the same number of books as the Bible (66).
+     */
+    numberOfBooks: number;
+
+    /**
+     * The total number of chapters that are contained in this translation.
+     *
+     * Complete translations should have the same number of chapters as the Bible (1,189).
+     */
+    totalNumberOfChapters: number;
+
+    /**
+     * The total number of verses that are contained in this translation.
+     *
+     * Complete translations should have the same number of verses as the Bible (around 31,102 - some translations exclude verses based on the aparent likelyhood of existing in the original source texts).
+     */
+    totalNumberOfVerses: number;
+
+    /**
+     * The total number of apocryphal books that are contained in this translation.
+     */
+    numberOfApocryphalBooks?: number;
+
+    /**
+     * The total number of apocryphal chapters that are contained in this translation.
+     */
+    totalNumberOfApocryphalChapters?: number;
+
+    /**
+     * the total number of apocryphal verses that are contained in this translation.
+     */
+    totalNumberOfApocryphalVerses?: number;
+
+    /**
+     * Gets the name of the language that the translation is in.
+     * Null or undefined if the name of the language is not known.
+     */
+    languageName?: string;
+
+    /**
+     * Gets the name of the language in English.
+     * Null or undefined if the language doesn't have an english name.
+     */
+    languageEnglishName?: string;
+
+    /**
+     * The API link for downloading the complete translation as a single JSON file.
+     *
+     * Undefined if complete translation files are not available.
+     */
+    completeTranslationApiLink?: string;
+}
+
+/**
+ * Defines the complete translation download data.
+ * Maps to the /api/:translationId/complete.json endpoint.
+ */
+export interface ApiTranslationComplete {
+    /**
+     * The translation metadata.
+     */
+    translation: ApiTranslation;
+
+    /**
+     * The complete list of books with all their chapters.
+     */
+    books: ApiTranslationCompleteBook[];
+}
+
+/**
+ * A book in the complete translation download.
+ */
+export interface ApiTranslationCompleteBook {
+    /**
+     * The ID of the book.
+     */
+    id: string;
+
+    /**
+     * The name of the book from the translation.
+     */
+    name: string;
+
+    /**
+     * The common name for the book.
+     */
+    commonName: string;
+
+    /**
+     * The title of the book.
+     */
+    title: string | null;
+
+    /**
+     * The order of the book.
+     */
+    order: number;
+
+    /**
+     * The number of chapters in the book.
+     */
+    numberOfChapters: number;
+
+    /**
+     * The total number of verses in the book.
+     */
+    totalNumberOfVerses: number;
+
+    /**
+     * Whether the book is apocryphal.
+     */
+    isApocryphal?: boolean;
+
+    /**
+     * The complete list of chapters with all content.
+     */
+    chapters: TranslationBookChapter[];
+}
+
+/**
+ * Defines a commentary that is used in the API.
+ */
+export interface ApiCommentary extends Commentary {
+    /**
+     * The API link for the list of available books for this translation.
+     */
+    listOfBooksApiLink: string;
+
+    /**
+     * The API link for the list of available profiles for this commentary.
+     */
+    listOfProfilesApiLink: string;
+
+    /**
+     * The available list of formats.
+     */
+    availableFormats: ('json' | 'usfm')[];
+
+    /**
+     * The number of books that are contained in this commentary.
+     *
+     * Complete commentaries should have the same number of books as the Bible (66).
+     */
+    numberOfBooks: number;
+
+    /**
+     * The total number of chapters that are contained in this translation.
+     *
+     * Complete commentaries should have the same number of chapters as the Bible (1,189).
+     */
+    totalNumberOfChapters: number;
+
+    /**
+     * The total number of verses that are contained in this commentary.
+     *
+     * Complete commentaries should have the same number of verses as the Bible (around 31,102 - some commentaries exclude verses based on the aparent likelyhood of existing in the original source texts).
+     */
+    totalNumberOfVerses: number;
+
+    /**
+     * The total number of profiles that are contained in this commentary.
+     *
+     * Profiles are used to provide additional information about people and people groups that are mentioned in the Bible.
+     */
+    totalNumberOfProfiles: number;
+
+    /**
+     * Gets the name of the language that the commentary is in.
+     * Null or undefined if the name of the language is not known.
+     */
+    languageName?: string;
+
+    /**
+     * Gets the name of the language in English.
+     * Null or undefined if the language doesn't have an english name.
+     */
+    languageEnglishName?: string;
+}
+
+/**
+ * Defines an interface that contains information about the books that are available for a translation.
+ */
+export interface ApiTranslationBooks {
+    /**
+     * The translation information for the books.
+     */
+    translation: ApiTranslation;
+
+    /**
+     * The list of books that are available for the translation.
+     */
+    books: ApiTranslationBook[];
+}
+
+/**
+ * Defines an interface that contains information about the books that are available for a commentary.
+ */
+export interface ApiCommentaryBooks {
+    /**
+     * The commentary information for the books.
+     */
+    commentary: ApiCommentary;
+
+    /**
+     * The list of books that are available for the commentary.
+     */
+    books: ApiCommentaryBook[];
+}
+
+/**
+ * Defines an interface that contains information about the books that are available for a dataset.
+ */
+export interface ApiDatasetBooks {
+    /**
+     * The dataset information for the books.
+     */
+    dataset: ApiDataset;
+
+    /**
+     * The list of books that are available for the dataset.
+     */
+    books: ApiDatasetBook[];
+}
+
+/**
+ * Defines an interface that contains information about the profiles that are available for a commentary.
+ */
+export interface ApiCommentaryProfiles {
+    /**
+     * The commentary information for the books.
+     */
+    commentary: ApiCommentary;
+
+    /**
+     * The list of profiles that are available for the commentary.
+     */
+    profiles: ApiCommentaryProfile[];
+}
+
+/**
+ * Defines an interface that contains information about a profile.
+ */
+export interface ApiCommentaryProfile extends CommentaryProfile {
+    /**
+     * The link to this profile.
+     */
+    thisProfileLink: string;
+
+    /**
+     * The link to the chapter that this profile references in the commentary.
+     */
+    referenceChapterLink: string | null;
+}
+
+/**
+ * Defines a translation book that is used in the API.
+ */
+export interface ApiTranslationBook extends TranslationBook {
+    /**
+     * The number of the first chapter in the book.
+     */
+    firstChapterNumber: number;
+
+    /**
+     * The link to the first chapter of the book.
+     */
+    firstChapterApiLink: string;
+
+    /**
+     * The number of the last chapter in the book.
+     */
+    lastChapterNumber: number;
+
+    /**
+     * The link to the last chapter of the book.
+     */
+    lastChapterApiLink: string;
+
+    /**
+     * The number of chapters that the book contains.
+     */
+    numberOfChapters: number;
+
+    /**
+     * The number of verses that the book contains.
+     */
+    totalNumberOfVerses: number;
+}
+
+/**
+ * Defines a commentary book that is used in the API.
+ */
+export interface ApiCommentaryBook extends CommentaryBook {
+    /**
+     * The number of the first chapter in the book.
+     *
+     * Null if the comentary book has no chapters.
+     */
+    firstChapterNumber: number | null;
+
+    /**
+     * The link to the first chapter of the book.
+     *
+     * Null if the comentary book has no chapters.
+     */
+    firstChapterApiLink: string | null;
+
+    /**
+     * The number of the last chapter in the book.
+     *
+     * Null if the comentary book has no chapters.
+     */
+    lastChapterNumber: number | null;
+
+    /**
+     * The link to the last chapter of the book.
+     *
+     * Null if the comentary book has no chapters.
+     */
+    lastChapterApiLink: string | null;
+
+    /**
+     * The number of chapters that the book contains.
+     */
+    numberOfChapters: number;
+
+    /**
+     * The number of verses that the book contains.
+     */
+    totalNumberOfVerses: number;
+}
+
+/**
+ * Defines an interface that contains information about a book in a dataset.
+ */
+export interface ApiDatasetBook extends DatasetBook {
+    /**
+     * The number of the first chapter in the book.
+     */
+    firstChapterNumber: number;
+
+    /**
+     * The link to the first chapter of the book.
+     */
+    firstChapterApiLink: string;
+
+    /**
+     * The number of the last chapter in the book.
+     */
+    lastChapterNumber: number;
+
+    /**
+     * The link to the last chapter of the book.
+     */
+    lastChapterApiLink: string;
+
+    /**
+     * The number of chapters that the book contains.
+     */
+    numberOfChapters: number;
+
+    /**
+     * The number of verses that the book contains.
+     */
+    totalNumberOfVerses: number;
+
+    /**
+     * The number of references that the book contains.
+     */
+    totalNumberOfReferences: number;
+}
+
+/**
+ * Defines an interface that contains information about a book chapter.
+ */
+export interface ApiTranslationBookChapter extends TranslationBookChapter {
+    /**
+     * The translation information for the book chapter.
+     */
+    translation: ApiTranslation;
+
+    /**
+     * The book information for the book chapter.
+     */
+    book: ApiTranslationBook;
+
+    /**
+     * The link to this chapter.
+     */
+    thisChapterLink: string;
+
+    /**
+     * The link to the next chapter.
+     * Null if this is the last chapter in the translation.
+     */
+    nextChapterApiLink: string | null;
+
+    /**
+     * The links to the audio versions for the next chapter.
+     * Null if this is the last chapter in the translation.
+     */
+    nextChapterAudioLinks: TranslationBookChapterAudioLinks | null;
+
+    /**
+     * The link to the previous chapter.
+     * Null if this is the first chapter in the translation.
+     */
+    previousChapterApiLink: string | null;
+
+    /**
+     * The links to the audio versions for the previous chapter.
+     * Null if this is the first chapter in the translation.
+     */
+    previousChapterAudioLinks: TranslationBookChapterAudioLinks | null;
+
+    /**
+     * The number of verses that the chapter contains.
+     */
+    numberOfVerses: number;
+}
+
+/**
+ * Defines an interface that contains information about a book chapter.
+ */
+export interface ApiCommentaryBookChapter extends CommentaryBookChapter {
+    /**
+     * The commentary information for the book chapter.
+     */
+    commentary: ApiCommentary;
+
+    /**
+     * The book information for the book chapter.
+     */
+    book: ApiCommentaryBook;
+
+    /**
+     * The link to this chapter.
+     */
+    thisChapterLink: string;
+
+    /**
+     * The link to the next chapter.
+     * Null if this is the last chapter in the translation.
+     */
+    nextChapterApiLink: string | null;
+
+    /**
+     * The link to the previous chapter.
+     * Null if this is the first chapter in the translation.
+     */
+    previousChapterApiLink: string | null;
+
+    /**
+     * The number of verses that the chapter contains.
+     */
+    numberOfVerses: number;
+}
+
+/**
+ * Defines an interface that contains information about a book chapter.
+ */
+export interface ApiDatasetBookChapter extends DatasetBookChapter {
+    /**
+     * The dataset information for the book chapter.
+     */
+    dataset: ApiDataset;
+
+    /**
+     * The book information for the book chapter.
+     */
+    book: ApiDatasetBook;
+
+    /**
+     * The link to this chapter.
+     */
+    thisChapterLink: string;
+
+    /**
+     * The link to the next chapter.
+     * Null if this is the last chapter in the translation.
+     */
+    nextChapterApiLink: string | null;
+
+    /**
+     * The link to the previous chapter.
+     * Null if this is the first chapter in the translation.
+     */
+    previousChapterApiLink: string | null;
+
+    /**
+     * The number of verses that the chapter contains.
+     */
+    numberOfVerses: number;
+
+    /**
+     * The number of references that the chapter contains.
+     */
+    numberOfReferences: number;
+}
+
+export interface ApiTranslationBookChapterAudio {
+    /**
+     * The chapter that the audio is for.
+     */
+    chapter: ApiTranslationBookChapter;
+
+    /**
+     * The link that the audio should be placed at.
+     */
+    link: string;
+
+    /**
+     * The original URL of the audio.
+     */
+    originalUrl: string;
+}
+
+export interface ApiCommentaryProfileContent {
+    /**
+     * The commentary information for the profile.
+     */
+    commentary: ApiCommentary;
+
+    /**
+     * The information about the profile.
+     */
+    profile: ApiCommentaryProfile;
+
+    /**
+     * The content of the profile.
+     */
+    content: string[];
+}
+
+/**
+ * The options for generating the API.
+ */
+export interface GenerateApiOptions {
+    /**
+     * Whether to use the common name for the book chapter API link. If false, then book IDs are used.
+     * Audio URLs will always use the book ID.
+     * Defaults to false.
+     */
+    useCommonName?: boolean;
+
+    /**
+     * Whether to replace the audio URLs in the dataset with ones that are hosted locally.
+     * If true, then the audio URLs in the dataset will be replaced with ones that reference files hosted by the API itself.
+     * If false, then the audio URLs in the dataset will be left as is.
+     * Defaults to false.
+     */
+    generateAudioFiles?: boolean;
+
+    /**
+     * Gets the english name of the given language.
+     * If not provided, then the english name for the language will be unknown and omitted.
+     * @param language The language to get the english name for.
+     */
+    getEnglishName?: (language: string) => string | null | undefined;
+
+    /**
+     * Gets the native name of the given language.
+     * If not provided, then the native name for the language will be unknown and omitted.
+     * @param language The language to get the native name for.
+     */
+    getNativeName?: (language: string) => string | null | undefined;
+
+    /**
+     * The prefix that should be added to paths that are generated.
+     */
+    pathPrefix?: string;
+
+    /**
+     * Whether to generate complete translation files for each translation.
+     */
+    generateCompleteTranslationFiles?: boolean;
+}
+
+/**
+ * Generates the API output for the given dataset.
+ * @param dataset The dataset to generate the API for.
+ * @param options The options for generating the API.
+ */
+export function generateApiForDataset(
+    dataset: DatasetOutput,
+    options: GenerateApiOptions = {}
+): ApiOutput {
+    const { useCommonName, pathPrefix } = options;
+    const apiPathPrefix = pathPrefix ? pathPrefix : '';
+    let api: ApiOutput = {
+        availableTranslations: {
+            translations: [],
+        },
+        translationBooks: [],
+        translationBookChapters: [],
+        translationBookChapterAudio: [],
+        translationComplete: [],
+        availableCommentaries: {
+            commentaries: [],
+        },
+        commentaryBookChapters: [],
+        commentaryBooks: [],
+        commentaryProfiles: [],
+        commentaryProfileContents: [],
+        pathPrefix: apiPathPrefix,
+    };
+
+    const getNativeName = options.getNativeName;
+    const getEnglishName = options.getEnglishName;
+
+    for (let { books, ...translation } of dataset.translations) {
+        let numberOfBooks = 0;
+        let numberOfApocryphalBooks = 0;
+
+        for (let book of books) {
+            if (book.isApocryphal) {
+                numberOfApocryphalBooks++;
+            } else {
+                numberOfBooks++;
+            }
+        }
+
+        const apiTranslation: ApiTranslation = {
+            ...translation,
+            availableFormats: ['json'],
+            listOfBooksApiLink: listOfBooksApiLink(
+                translation.id,
+                apiPathPrefix
+            ),
+            completeTranslationApiLink: options.generateCompleteTranslationFiles
+                ? completeTranslationApiLink(translation.id, apiPathPrefix)
+                : undefined,
+            numberOfBooks,
+            totalNumberOfChapters: 0,
+            totalNumberOfVerses: 0,
+            languageName: getNativeName
+                ? (getNativeName(translation.language) ?? undefined)
+                : undefined,
+            languageEnglishName: getEnglishName
+                ? (getEnglishName(translation.language) ?? undefined)
+                : undefined,
+        };
+
+        if (numberOfApocryphalBooks > 0) {
+            apiTranslation.numberOfApocryphalBooks = numberOfApocryphalBooks;
+        }
+
+        const translationBooks: ApiTranslationBooks = {
+            translation: apiTranslation,
+            books: [],
+        };
+
+        let translationChapters: ApiTranslationBookChapter[] = [];
+
+        for (let { chapters, ...book } of books) {
+            const firstChapterNumber = chapters[0]?.chapter.number;
+            const lastChapterNumber =
+                chapters[chapters.length - 1]?.chapter.number;
+            const apiBook: ApiTranslationBook = {
+                ...book,
+                firstChapterNumber,
+                firstChapterApiLink: bookChapterApiLink(
+                    translation.id,
+                    getBookLink(book),
+                    firstChapterNumber,
+                    'json',
+                    apiPathPrefix
+                ),
+                lastChapterNumber,
+                lastChapterApiLink: bookChapterApiLink(
+                    translation.id,
+                    getBookLink(book),
+                    lastChapterNumber,
+                    'json',
+                    apiPathPrefix
+                ),
+                numberOfChapters: chapters.length,
+                totalNumberOfVerses: 0,
+            };
+
+            for (let { chapter, thisChapterAudioLinks } of chapters) {
+                const audio: TranslationBookChapterAudioLinks = {};
+                const apiBookChapter: ApiTranslationBookChapter = {
+                    translation: apiTranslation,
+                    book: apiBook,
+                    chapter: chapter,
+                    thisChapterLink: bookChapterApiLink(
+                        translation.id,
+                        getBookLink(book),
+                        chapter.number,
+                        'json',
+                        apiPathPrefix
+                    ),
+                    thisChapterAudioLinks: audio,
+                    nextChapterApiLink: null,
+                    nextChapterAudioLinks: null,
+                    previousChapterApiLink: null,
+                    previousChapterAudioLinks: null,
+                    numberOfVerses: 0,
+                };
+
+                for (let reader in thisChapterAudioLinks) {
+                    if (options.generateAudioFiles) {
+                        const apiAudio: ApiTranslationBookChapterAudio = {
+                            chapter: apiBookChapter,
+                            link: bookChapterAudioApiLink(
+                                translation.id,
+                                getBookLink(book),
+                                chapter.number,
+                                reader,
+                                apiPathPrefix
+                            ),
+                            originalUrl: thisChapterAudioLinks[reader],
+                        };
+                        audio[reader] = apiAudio.link;
+                        api.translationBookChapterAudio.push(apiAudio);
+                    } else {
+                        audio[reader] = thisChapterAudioLinks[reader];
+                    }
+                }
+
+                for (let c of chapter.content) {
+                    if (c.type === 'verse') {
+                        apiBookChapter.numberOfVerses++;
+                    }
+                }
+
+                apiBook.totalNumberOfVerses += apiBookChapter.numberOfVerses;
+
+                translationChapters.push(apiBookChapter);
+                api.translationBookChapters.push(apiBookChapter);
+            }
+
+            translationBooks.books.push(apiBook);
+
+            if (apiBook.isApocryphal) {
+                if (!apiTranslation.totalNumberOfApocryphalChapters) {
+                    apiTranslation.totalNumberOfApocryphalChapters = 0;
+                }
+                if (!apiTranslation.totalNumberOfApocryphalVerses) {
+                    apiTranslation.totalNumberOfApocryphalVerses = 0;
+                }
+                apiTranslation.totalNumberOfApocryphalChapters +=
+                    apiBook.numberOfChapters;
+                apiTranslation.totalNumberOfApocryphalVerses +=
+                    apiBook.totalNumberOfVerses;
+            } else {
+                apiTranslation.totalNumberOfChapters +=
+                    apiBook.numberOfChapters;
+                apiTranslation.totalNumberOfVerses +=
+                    apiBook.totalNumberOfVerses;
+            }
+        }
+
+        for (let i = 0; i < translationChapters.length; i++) {
+            if (i > 0) {
+                translationChapters[i].previousChapterApiLink =
+                    bookChapterApiLink(
+                        translation.id,
+                        getBookLink(translationChapters[i - 1].book),
+                        translationChapters[i - 1].chapter.number,
+                        'json',
+                        apiPathPrefix
+                    );
+                translationChapters[i].previousChapterAudioLinks =
+                    translationChapters[i - 1].thisChapterAudioLinks;
+            }
+
+            if (i < translationChapters.length - 1) {
+                translationChapters[i].nextChapterApiLink = bookChapterApiLink(
+                    translation.id,
+                    getBookLink(translationChapters[i + 1].book),
+                    translationChapters[i + 1].chapter.number,
+                    'json',
+                    apiPathPrefix
+                );
+                translationChapters[i].nextChapterAudioLinks =
+                    translationChapters[i + 1].thisChapterAudioLinks;
+            }
+        }
+
+        api.availableTranslations.translations.push(apiTranslation);
+        api.translationBooks.push(translationBooks);
+
+        if (options.generateCompleteTranslationFiles) {
+            // Build the complete translation data for download
+            const completeTranslation: ApiTranslationComplete = {
+                translation: apiTranslation,
+                books: translationBooks.books.map((book) => {
+                    const bookChapters = translationChapters.filter(
+                        (ch) => ch.book.id === book.id
+                    );
+                    return {
+                        id: book.id,
+                        name: book.name,
+                        commonName: book.commonName,
+                        title: book.title,
+                        order: book.order,
+                        numberOfChapters: book.numberOfChapters,
+                        totalNumberOfVerses: book.totalNumberOfVerses,
+                        isApocryphal: book.isApocryphal,
+                        chapters: bookChapters.map((ch) => ({
+                            numberOfVerses: ch.numberOfVerses,
+                            thisChapterAudioLinks: ch.thisChapterAudioLinks,
+                            chapter: ch.chapter,
+                        })),
+                    };
+                }),
+            };
+            api.translationComplete.push(completeTranslation);
+        }
+    }
+
+    for (let { books, profiles, ...commentary } of dataset.commentaries) {
+        const apiCommentary: ApiCommentary = {
+            ...commentary,
+            availableFormats: ['json'],
+            listOfBooksApiLink: listOfCommentaryBooksApiLink(
+                commentary.id,
+                apiPathPrefix
+            ),
+            listOfProfilesApiLink: profilesCommentaryApiLink(
+                commentary.id,
+                'json',
+                apiPathPrefix
+            ),
+            numberOfBooks: books.length,
+            totalNumberOfChapters: 0,
+            totalNumberOfVerses: 0,
+            totalNumberOfProfiles: 0,
+            languageName: getNativeName
+                ? (getNativeName(commentary.language) ?? undefined)
+                : undefined,
+            languageEnglishName: getEnglishName
+                ? (getEnglishName(commentary.language) ?? undefined)
+                : undefined,
+        };
+
+        const commentaryBooks: ApiCommentaryBooks = {
+            commentary: apiCommentary,
+            books: [],
+        };
+
+        const commentaryProfiles: ApiCommentaryProfiles = {
+            commentary: apiCommentary,
+            profiles: [],
+        };
+
+        let commentaryChapters: ApiCommentaryBookChapter[] = [];
+
+        for (let { chapters, ...book } of books) {
+            const firstChapterNumber = chapters[0]?.chapter.number ?? null;
+            const lastChapterNumber =
+                chapters[chapters.length - 1]?.chapter.number ?? null;
+            const apiBook: ApiCommentaryBook = {
+                ...book,
+                firstChapterNumber,
+                firstChapterApiLink: firstChapterNumber
+                    ? bookCommentaryChapterApiLink(
+                          commentary.id,
+                          getBookLink(book),
+                          firstChapterNumber,
+                          'json',
+                          apiPathPrefix
+                      )
+                    : null,
+                lastChapterNumber,
+                lastChapterApiLink: lastChapterNumber
+                    ? bookCommentaryChapterApiLink(
+                          commentary.id,
+                          getBookLink(book),
+                          lastChapterNumber,
+                          'json',
+                          apiPathPrefix
+                      )
+                    : null,
+                numberOfChapters: chapters.length,
+                totalNumberOfVerses: 0,
+            };
+
+            for (let { chapter } of chapters) {
+                const apiBookChapter: ApiCommentaryBookChapter = {
+                    commentary: apiCommentary,
+                    book: apiBook,
+                    chapter: chapter,
+                    thisChapterLink: bookCommentaryChapterApiLink(
+                        commentary.id,
+                        getBookLink(book),
+                        chapter.number,
+                        'json',
+                        apiPathPrefix
+                    ),
+                    nextChapterApiLink: null,
+                    previousChapterApiLink: null,
+                    numberOfVerses: 0,
+                };
+
+                for (let c of chapter.content) {
+                    if (c.type === 'verse') {
+                        apiBookChapter.numberOfVerses++;
+                    }
+                }
+
+                apiBook.totalNumberOfVerses += apiBookChapter.numberOfVerses;
+
+                commentaryChapters.push(apiBookChapter);
+                api.commentaryBookChapters.push(apiBookChapter);
+            }
+
+            commentaryBooks.books.push(apiBook);
+
+            apiCommentary.totalNumberOfChapters += apiBook.numberOfChapters;
+            apiCommentary.totalNumberOfVerses += apiBook.totalNumberOfVerses;
+        }
+
+        if (profiles) {
+            for (let profile of profiles) {
+                const apiProfile: ApiCommentaryProfile = {
+                    id: profile.id,
+                    reference: profile.reference,
+                    subject: profile.subject,
+                    thisProfileLink: profileCommentaryApiLink(
+                        commentary.id,
+                        profile.id,
+                        'json',
+                        apiPathPrefix
+                    ),
+                    referenceChapterLink: profile.reference
+                        ? bookCommentaryChapterApiLink(
+                              commentary.id,
+                              profile.reference.book,
+                              profile.reference.chapter,
+                              'json',
+                              apiPathPrefix
+                          )
+                        : null,
+                };
+
+                const apiProfileContent: ApiCommentaryProfileContent = {
+                    commentary: apiCommentary,
+                    profile: apiProfile,
+                    content: profile.content,
+                };
+
+                apiCommentary.totalNumberOfProfiles += 1;
+                commentaryProfiles.profiles.push(apiProfile);
+                api.commentaryProfileContents.push(apiProfileContent);
+            }
+        }
+
+        for (let i = 0; i < commentaryChapters.length; i++) {
+            if (i > 0) {
+                commentaryChapters[i].previousChapterApiLink =
+                    bookCommentaryChapterApiLink(
+                        commentary.id,
+                        getBookLink(commentaryChapters[i - 1].book),
+                        commentaryChapters[i - 1].chapter.number,
+                        'json',
+                        apiPathPrefix
+                    );
+                // commentaryChapters[i].previousChapterAudioLinks =
+                //     commentaryChapters[i - 1].thisChapterAudioLinks;
+            }
+
+            if (i < commentaryChapters.length - 1) {
+                commentaryChapters[i].nextChapterApiLink =
+                    bookCommentaryChapterApiLink(
+                        commentary.id,
+                        getBookLink(commentaryChapters[i + 1].book),
+                        commentaryChapters[i + 1].chapter.number,
+                        'json',
+                        apiPathPrefix
+                    );
+                // commentaryChapters[i].nextChapterAudioLinks =
+                //     commentaryChapters[i + 1].thisChapterAudioLinks;
+            }
+        }
+
+        api.availableCommentaries.commentaries.push(apiCommentary);
+        api.commentaryBooks.push(commentaryBooks);
+        api.commentaryProfiles.push(commentaryProfiles);
+    }
+
+    for (let { books, ...datasetInfo } of dataset.datasets ?? []) {
+        const apiDataset: ApiDataset = {
+            ...datasetInfo,
+            availableFormats: ['json'],
+            listOfBooksApiLink: listOfDatasetBooksApiLink(
+                datasetInfo.id,
+                apiPathPrefix
+            ),
+            numberOfBooks: books.length,
+            totalNumberOfChapters: 0,
+            totalNumberOfVerses: 0,
+            totalNumberOfReferences: 0,
+            languageName: getNativeName
+                ? (getNativeName(datasetInfo.language) ?? undefined)
+                : undefined,
+            languageEnglishName: getEnglishName
+                ? (getEnglishName(datasetInfo.language) ?? undefined)
+                : undefined,
+        };
+
+        const datasetBooks: ApiDatasetBooks = {
+            dataset: apiDataset,
+            books: [],
+        };
+
+        let datasetChapters: ApiDatasetBookChapter[] = [];
+
+        for (let { chapters, ...book } of books) {
+            const firstChapterNumber = chapters[0]?.chapter.number ?? null;
+            const lastChapterNumber =
+                chapters[chapters.length - 1]?.chapter.number ?? null;
+            const apiBook: ApiDatasetBook = {
+                ...book,
+                firstChapterNumber,
+                firstChapterApiLink: bookDatasetChapterApiLink(
+                    datasetInfo.id,
+                    book.id,
+                    firstChapterNumber,
+                    'json',
+                    apiPathPrefix
+                ),
+                lastChapterNumber,
+                lastChapterApiLink: bookDatasetChapterApiLink(
+                    datasetInfo.id,
+                    book.id,
+                    lastChapterNumber,
+                    'json',
+                    apiPathPrefix
+                ),
+                numberOfChapters: chapters.length,
+                totalNumberOfVerses: 0,
+                totalNumberOfReferences: 0,
+            };
+
+            for (let { chapter } of chapters) {
+                const apiBookChapter: ApiDatasetBookChapter = {
+                    dataset: apiDataset,
+                    book: apiBook,
+                    chapter: chapter,
+                    thisChapterLink: bookDatasetChapterApiLink(
+                        datasetInfo.id,
+                        book.id,
+                        chapter.number,
+                        'json',
+                        apiPathPrefix
+                    ),
+                    nextChapterApiLink: null,
+                    previousChapterApiLink: null,
+                    numberOfVerses: chapter.content.length,
+                    numberOfReferences: 0,
+                };
+
+                // apiBookChapter.numberOfVerses += ;
+                for (let verse of chapter.content) {
+                    apiBookChapter.numberOfReferences +=
+                        verse.references.length;
+                }
+
+                apiBook.totalNumberOfVerses += apiBookChapter.numberOfVerses;
+                apiBook.totalNumberOfReferences +=
+                    apiBookChapter.numberOfReferences;
+
+                datasetChapters.push(apiBookChapter);
+                if (!api.datasetBookChapters) {
+                    api.datasetBookChapters = [];
+                }
+                api.datasetBookChapters.push(apiBookChapter);
+            }
+
+            datasetBooks.books.push(apiBook);
+
+            apiDataset.totalNumberOfChapters += apiBook.numberOfChapters;
+            apiDataset.totalNumberOfVerses += apiBook.totalNumberOfVerses;
+            apiDataset.totalNumberOfReferences +=
+                apiBook.totalNumberOfReferences;
+        }
+
+        for (let i = 0; i < datasetChapters.length; i++) {
+            if (i > 0) {
+                datasetChapters[i].previousChapterApiLink =
+                    bookDatasetChapterApiLink(
+                        datasetInfo.id,
+                        datasetChapters[i - 1].book.id,
+                        datasetChapters[i - 1].chapter.number,
+                        'json',
+                        apiPathPrefix
+                    );
+            }
+
+            if (i < datasetChapters.length - 1) {
+                datasetChapters[i].nextChapterApiLink =
+                    bookDatasetChapterApiLink(
+                        datasetInfo.id,
+                        datasetChapters[i + 1].book.id,
+                        datasetChapters[i + 1].chapter.number,
+                        'json',
+                        apiPathPrefix
+                    );
+            }
+        }
+
+        if (!api.availableDatasets) {
+            api.availableDatasets = {
+                datasets: [],
+            };
+        }
+        api.availableDatasets.datasets.push(apiDataset);
+        if (!api.datasetBooks) {
+            api.datasetBooks = [];
+        }
+        api.datasetBooks.push(datasetBooks);
+    }
+
+    return api;
+
+    function getBookLink(book: TranslationBook | CommentaryBook): string {
+        return useCommonName ? book.commonName : book.id;
+    }
+}
+
+/**
+ * Generates the output files for the given API.
+ * @param api The API that the files should be generated for.
+ */
+export function generateFilesForApi(api: ApiOutput): OutputFile[] {
+    let files: OutputFile[] = [];
+
+    files.push(
+        jsonFile(
+            `${api.pathPrefix}/api/available_translations.json`,
+            api.availableTranslations,
+            true
+        )
+    );
+    for (let translationBooks of api.translationBooks) {
+        files.push(
+            jsonFile(
+                translationBooks.translation.listOfBooksApiLink,
+                translationBooks
+            )
+        );
+    }
+
+    for (let bookChapter of api.translationBookChapters) {
+        files.push(jsonFile(bookChapter.thisChapterLink, bookChapter));
+    }
+
+    for (let audio of api.translationBookChapterAudio) {
+        files.push(downloadedFile(audio.link, audio.originalUrl));
+    }
+
+    // Generate complete translation download files
+    for (let complete of api.translationComplete) {
+        if (complete.translation.completeTranslationApiLink) {
+            files.push(
+                jsonFile(
+                    complete.translation.completeTranslationApiLink,
+                    complete
+                )
+            );
+        }
+    }
+
+    files.push(
+        jsonFile(
+            `${api.pathPrefix}/api/available_commentaries.json`,
+            api.availableCommentaries,
+            true
+        )
+    );
+    for (let commentaryBooks of api.commentaryBooks) {
+        files.push(
+            jsonFile(
+                commentaryBooks.commentary.listOfBooksApiLink,
+                commentaryBooks
+            )
+        );
+    }
+
+    for (let commentaryProfiles of api.commentaryProfiles) {
+        files.push(
+            jsonFile(
+                commentaryProfiles.commentary.listOfProfilesApiLink,
+                commentaryProfiles
+            )
+        );
+    }
+
+    for (let profileContent of api.commentaryProfileContents) {
+        files.push(
+            jsonFile(profileContent.profile.thisProfileLink, profileContent)
+        );
+    }
+
+    for (let bookChapter of api.commentaryBookChapters) {
+        files.push(jsonFile(bookChapter.thisChapterLink, bookChapter));
+    }
+
+    if (api.availableDatasets) {
+        files.push(
+            jsonFile(
+                `${api.pathPrefix}/api/available_datasets.json`,
+                api.availableDatasets,
+                true
+            )
+        );
+    }
+
+    if (api.datasetBooks) {
+        for (let datasetBook of api.datasetBooks) {
+            files.push(
+                jsonFile(datasetBook.dataset.listOfBooksApiLink, datasetBook)
+            );
+        }
+    }
+
+    if (api.datasetBookChapters) {
+        for (let datasetBookChapter of api.datasetBookChapters) {
+            files.push(
+                jsonFile(datasetBookChapter.thisChapterLink, datasetBookChapter)
+            );
+        }
+    }
+
+    // for (let audio of api.translationBookChapterAudio) {
+    //     files.push(downloadedFile(audio.link, audio.originalUrl));
+    // }
+
+    return files;
+}
+
+/**
+ * Generates the output files for the given datasets.
+ * @param datasets The datasets to generate the output files for.
+ * @param options The options for generating the API files.
+ */
+export async function* generateOutputFilesFromDatasets(
+    datasets: AsyncIterable<DatasetOutput>,
+    options?: GenerateApiOptions
+): AsyncGenerator<OutputFile[]> {
+    for await (let dataset of datasets) {
+        const api = generateApiForDataset(dataset, options);
+        const files = generateFilesForApi(api);
+
+        yield files;
+    }
+}
+
+/**
+ * Gets the API Link for the list of books endpoint for a translation.
+ * @param translationId The ID of the translation.
+ * @returns
+ */
+export function listOfBooksApiLink(
+    translationId: string,
+    prefix: string = ''
+): string {
+    return `${prefix}/api/${translationId}/books.json`;
+}
+
+/**
+ * Gets the API Link for the complete translation download endpoint.
+ * @param translationId The ID of the translation.
+ * @param prefix The path prefix.
+ * @returns
+ */
+export function completeTranslationApiLink(
+    translationId: string,
+    prefix: string = ''
+): string {
+    return `${prefix}/api/${translationId}/complete.json`;
+}
+
+/**
+ * Gets the API Link for the list of books endpoint for a commentary.
+ * @param commentaryId The ID of the commentary.
+ * @returns
+ */
+export function listOfCommentaryBooksApiLink(
+    commentaryId: string,
+    prefix: string = ''
+): string {
+    return `${prefix}/api/c/${commentaryId}/books.json`;
+}
+
+/**
+ * Gets the API Link for the list of books endpoint for a dataset.
+ * @param datasetId The ID of the dataset.
+ * @returns
+ */
+export function listOfDatasetBooksApiLink(
+    datasetId: string,
+    prefix: string = ''
+): string {
+    return `${prefix}/api/d/${datasetId}/books.json`;
+}
+
+/**
+ * Getes the API link for a book chapter.
+ * @param translationId The ID of the translation.
+ * @param commonName The name of the book.
+ * @param chapterNumber The number of the book.
+ * @param extension The extension of the file.
+ */
+export function bookChapterApiLink(
+    translationId: string,
+    commonName: string,
+    chapterNumber: number,
+    extension: string,
+    prefix: string = ''
+) {
+    return `${prefix}/api/${translationId}/${replaceSpacesWithUnderscores(
+        commonName
+    )}/${chapterNumber}.${extension}`;
+}
+
+/**
+ * Getes the API link for a book chapter.
+ * @param translationId The ID of the translation.
+ * @param commonName The name of the book.
+ * @param chapterNumber The number of the book.
+ * @param extension The extension of the file.
+ */
+export function bookCommentaryChapterApiLink(
+    translationId: string,
+    commonName: string,
+    chapterNumber: number,
+    extension: string,
+    prefix: string = ''
+) {
+    return `${prefix}/api/c/${translationId}/${replaceSpacesWithUnderscores(
+        commonName
+    )}/${chapterNumber}.${extension}`;
+}
+
+export function bookChapterAudioApiLink(
+    translationId: string,
+    bookId: string,
+    chapterNumber: number,
+    reader: string,
+    prefix: string = ''
+) {
+    return `${prefix}/api/${translationId}/${replaceSpacesWithUnderscores(
+        bookId
+    )}/${chapterNumber}.${reader}.mp3`;
+}
+
+/**
+ * Getes the API link for a book chapter.
+ * @param translationId The ID of the translation.
+ * @param commonName The name of the book.
+ * @param chapterNumber The number of the book.
+ * @param extension The extension of the file.
+ */
+export function bookDatasetChapterApiLink(
+    translationId: string,
+    commonName: string,
+    chapterNumber: number,
+    extension: string,
+    prefix: string = ''
+) {
+    return `${prefix}/api/d/${translationId}/${replaceSpacesWithUnderscores(
+        commonName
+    )}/${chapterNumber}.${extension}`;
+}
+
+/**
+ * Gets the API link for a profile.
+ * @param translationId The ID of the translation.
+ * @param profileId The ID of the profile.
+ * @param extension The extension of the file.
+ */
+export function profilesCommentaryApiLink(
+    translationId: string,
+    extension: string,
+    prefix: string = ''
+) {
+    return `${prefix}/api/c/${translationId}/profiles.${extension}`;
+}
+
+/**
+ * Gets the API link for a profile.
+ * @param translationId The ID of the translation.
+ * @param profileId The ID of the profile.
+ * @param extension The extension of the file.
+ */
+export function profileCommentaryApiLink(
+    translationId: string,
+    profileId: string,
+    extension: string,
+    prefix: string = ''
+) {
+    return `${prefix}/api/c/${translationId}/profiles/${replaceSpacesWithUnderscores(
+        profileId
+    )}.${extension}`;
+}
+
+export function jsonFile(
+    path: string,
+    content: any,
+    mergable?: boolean
+): OutputFile {
+    return {
+        path,
+        content,
+        mergable,
+    };
+}
+
+export function downloadedFile(path: string, url: string): OutputFile {
+    return {
+        path,
+        content: () => fetch(url).then((response) => response.body),
+    };
+}
+
+export function replaceSpacesWithUnderscores(str: string): string {
+    return str.replace(/[<>:"/\\|?*\s]/g, '_');
+}

--- a/vendor/common-types.ts
+++ b/vendor/common-types.ts
@@ -1,0 +1,662 @@
+import { VerseRef } from '../utils.js';
+
+/**
+ * Defines an interface that contains information about a input file.
+ */
+export type InputFile = InputTranslationFile | InputCommentaryFile;
+
+export interface InputFileBase {
+    name?: string;
+    content: string;
+    sha256?: string;
+}
+
+export type InputFileMetadata =
+    | InputTranslationMetadata
+    | InputCommentaryMetadata;
+
+export interface InputTranslationFile extends InputFileBase {
+    fileType: 'usfm' | 'usx' | 'json' | 'lockman';
+    metadata: InputTranslationMetadata;
+}
+
+export interface InputCommentaryFile extends InputFileBase {
+    fileType: 'commentary/csv' | 'commentary/tyndale-xml';
+    metadata: InputCommentaryMetadata;
+}
+
+export type OutputFileContent = object | ReadableStream;
+
+/**
+ * Defines an interface that contains information about a output file.
+ */
+export interface OutputFile {
+    /**
+     * The path that the file should be stored at.
+     */
+    path: string;
+
+    /**
+     * The content of the file.
+     */
+    content: OutputFileContent | (() => Promise<OutputFileContent>);
+
+    /**
+     * Whether the file can be merged with files of the same name but from other datasets.
+     */
+    mergable?: boolean;
+}
+
+export interface MetadataBase {
+    /**
+     * The name of the translation.
+     */
+    name: string;
+
+    /**
+     * The english name of the translation.
+     */
+    englishName: string;
+
+    /**
+     * The website for the translation.
+     */
+    website: string;
+
+    /**
+     * The URL that the license for the translation can be found.
+     */
+    licenseUrl: string;
+
+    /**
+     * The notice that should be displayed when displaying content from the translation.
+     */
+    licenseNotice?: string | null;
+
+    /**
+     * The ISO 639 letter language tag that the translation is primarily in.
+     */
+    language: string;
+
+    /**
+     * The direction that the text is written in.
+     */
+    direction: 'ltr' | 'rtl';
+}
+
+/**
+ * The metadata for a translation that is input into the generator.
+ */
+export interface InputTranslationMetadata extends MetadataBase {
+    /**
+     * The ID of the translation.
+     */
+    id: string;
+
+    /**
+     * The short name for the translation.
+     */
+    shortName: string;
+}
+
+/**
+ * The metadata for a translation that is input into the generator.
+ */
+export interface InputCommentaryMetadata extends MetadataBase {
+    /**
+     * The ID of the commentary.
+     */
+    id: string;
+}
+
+/**
+ * Defines an interface that contains information about a translation.
+ */
+export interface Translation {
+    /**
+     * The ID of the translation.
+     */
+    id: string;
+
+    /**
+     * The name of the translation.
+     */
+    name: string;
+
+    /**
+     * The website for the translation.
+     */
+    website: string;
+
+    /**
+     * The URL that the license for the translation can be found.
+     */
+    licenseUrl: string;
+
+    /**
+     * The API-added notes for the license.
+     */
+    licenseNotes?: string | null;
+
+    /**
+     * The notice that should be displayed when displaying content from the translation.
+     */
+    licenseNotice?: string | null;
+
+    /**
+     * The short name for the translation.
+     */
+    shortName?: string;
+
+    /**
+     * The English name for the translation.
+     */
+    englishName: string;
+
+    /**
+     * The ISO 639 3-letter language tag that the translation is primarily in.
+     */
+    language: string;
+
+    /**
+     * The direction that the language is written in.
+     * "ltr" indicates that the text is written from the left side of the page to the right.
+     * "rtl" indicates that the text is written from the right side of the page to the left.
+     */
+    textDirection: 'ltr' | 'rtl';
+}
+
+/**
+ * Defines an interface that contains information about a commentary.
+ */
+export interface Commentary {
+    /**
+     * The ID of the commentary.
+     */
+    id: string;
+
+    /**
+     * The name of the commentary.
+     */
+    name: string;
+
+    /**
+     * The website for the commentary.
+     */
+    website: string;
+
+    /**
+     * The URL that the license for the commentary can be found.
+     */
+    licenseUrl: string;
+
+    /**
+     * The API-added notes for the license.
+     */
+    licenseNotes?: string | null;
+
+    /**
+     * The english name for the commentary.
+     */
+    englishName: string;
+
+    /**
+     * The ISO 639 3-letter language tag that the translation is primarily in.
+     */
+    language: string;
+
+    /**
+     * The direction that the language is written in.
+     * "ltr" indicates that the text is written from the left side of the page to the right.
+     * "rtl" indicates that the text is written from the right side of the page to the left.
+     */
+    textDirection: 'ltr' | 'rtl';
+}
+
+export interface Dataset {
+    /**
+     * The ID of the dataset.
+     */
+    id: string;
+
+    /**
+     * The name of the dataset.
+     */
+    name: string;
+
+    /**
+     * The website for the dataset.
+     */
+    website: string;
+
+    /**
+     * The URL that the license for the dataset can be found.
+     */
+    licenseUrl: string;
+
+    /**
+     * The API-added notes for the license.
+     */
+    licenseNotes?: string | null;
+
+    /**
+     * The English name for the dataset.
+     */
+    englishName: string;
+
+    /**
+     * The ISO 639 3-letter language tag that the dataset is primarily in.
+     */
+    language: string;
+
+    /**
+     * The direction that the language is written in.
+     */
+    textDirection: 'ltr' | 'rtl';
+}
+
+/**
+ * Defines an interface that contains information about a book.
+ */
+export interface TranslationBook {
+    /**
+     * The ID of the book. Should match the USFM book ID.
+     */
+    id: string;
+
+    /**
+     * The name that the translation provided for the book.
+     */
+    name: string;
+
+    /**
+     * The common name for the book.
+     */
+    commonName: string;
+
+    /**
+     * The title of the book.
+     * This is usually a more descriptive version of the book name.
+     * If not available, then one was not provided by the translation.
+     */
+    title: string | null;
+
+    /**
+     * The numerical order of the book in the translation.
+     */
+    order: number;
+
+    /**
+     * Whether the book is an apocryphal book.
+     */
+    isApocryphal?: boolean;
+}
+
+/**
+ * Defines an interface that contains information about a book in a commentary.
+ */
+export interface CommentaryBook {
+    /**
+     * The ID of the book. Should match the USFM book ID.
+     */
+    id: string;
+
+    /**
+     * The name that the commentary provided for the book.
+     */
+    name: string;
+
+    /**
+     * The common name for the book.
+     */
+    commonName: string;
+
+    /**
+     * The commentary's introduction for the book.
+     */
+    introduction?: string;
+
+    /**
+     * The summary of the commentary's introduction for the book.
+     */
+    introductionSummary?: string;
+
+    /**
+     * The order of the book in the Bible.
+     */
+    order: number;
+}
+
+/**
+ * Defines an interface that contains information about a dataset book.
+ */
+export interface DatasetBook {
+    /**
+     * The ID of the book. Should match the USFM book ID.
+     */
+    id: string;
+
+    /**
+     * The order of the book in the Bible.
+     */
+    order: number;
+}
+
+/**
+ * Defines an interface that contains information about a chapter in a dataset.
+ */
+export interface DatasetBookChapter {
+    /**
+     * The data for the chapter.
+     */
+    chapter: DatasetChapterData;
+}
+
+export interface DatasetChapterData {
+    /**
+     * The number of the chapter.
+     */
+    number: number;
+
+    /**
+     * The content of the chapter.
+     */
+    content: DatasetChapterVerseContent[];
+}
+
+/**
+ * Defines an interface that contains information about a verse in a dataset chapter.
+ */
+export interface DatasetChapterVerseContent {
+    /**
+     * The number of the verse.
+     */
+    verse: number;
+
+    /**
+     * The list of references for the verse.
+     */
+    references: ScoredVerseRef[];
+}
+
+/**
+ * Defines an interface that contains information about a verse reference that has an arbitrary score attached to it.
+ */
+export interface ScoredVerseRef extends VerseRef {
+    /**
+     * The score of the verse reference.
+     */
+    score: number;
+}
+
+/**
+ * Defines an interface that contains information about a profile in a commentary.
+ */
+export interface CommentaryProfile {
+    /**
+     * The ID of the profile.
+     */
+    id: string;
+
+    /**
+     * The subject of the profile.
+     */
+    subject: string;
+
+    /**
+     * The Bible reference that the profile is associated with.
+     */
+    reference: VerseRef | null;
+}
+
+/**
+ * Defines an interface that contains information about a book chapter.
+ */
+export interface TranslationBookChapter {
+    /**
+     * The information for the chapter.
+     */
+    chapter: ChapterData;
+
+    /**
+     * The links to different audio versions for the chapter.
+     */
+    thisChapterAudioLinks: TranslationBookChapterAudioLinks;
+}
+
+/**
+ * Defines an interface that contains information about a book chapter in a commentary.
+ */
+export interface CommentaryBookChapter {
+    /**
+     * The information for the chapter.
+     */
+    chapter: CommentaryChapterData;
+}
+
+/**
+ * Defines an interface that contains the audio links for a book chapter.
+ */
+export interface TranslationBookChapterAudioLinks {
+    /**
+     * The reader for the chapter and the URL link to the audio file.
+     */
+    [reader: string]: string;
+}
+
+/**
+ * Defines an interface that represents data in a chapter.
+ */
+export interface ChapterData {
+    /**
+     * The number of the chapter.
+     */
+    number: number;
+
+    /**
+     * The content of the chapter.
+     */
+    content: ChapterContent[];
+
+    /**
+     * The list of footnotes for the chapter.
+     */
+    footnotes: ChapterFootnote[];
+}
+
+/**
+ * Defines an interface that represents data in a chapter in a commentary.
+ */
+export interface CommentaryChapterData {
+    /**
+     * The number of the chapter.
+     */
+    number: number;
+
+    /**
+     * The introduction that the commentary provided to the chapter.
+     * Not all commentaries provide an introduction to a chapter.
+     */
+    introduction?: string;
+
+    /**
+     * The content of the chapter.
+     */
+    content: ChapterVerse[];
+}
+
+/**
+ * A union type that represents a single piece of chapter content.
+ * A piece of chapter content can be one of the following things:
+ * - A heading.
+ * - A line break.
+ * - A verse.
+ * - A Hebrew Subtitle.
+ */
+export type ChapterContent =
+    | ChapterHeading
+    | ChapterLineBreak
+    | ChapterVerse
+    | ChapterHebrewSubtitle;
+
+/**
+ * A heading in a chapter.
+ */
+export interface ChapterHeading {
+    /**
+     * Indicates that the content represents a heading.
+     */
+    type: 'heading';
+
+    /**
+     * The content for the heading.
+     * If multiple strings are included in the array, they should be concatenated with a space.
+     */
+    content: string[];
+}
+
+/**
+ * A line break in a chapter.
+ */
+export interface ChapterLineBreak {
+    /**
+     * Indicates that the content represents a line break.
+     */
+    type: 'line_break';
+}
+
+/**
+ * A Hebrew Subtitle in a chapter.
+ * These are often used included as informational content that appeared in the original manuscripts.
+ * For example, Psalms 49 has the Hebrew Subtitle "To the choirmaster. A Psalm of the Sons of Korah."
+ */
+export interface ChapterHebrewSubtitle {
+    /**
+     * Indicates that the content represents a Hebrew Subtitle.
+     */
+    type: 'hebrew_subtitle';
+
+    /**
+     * The list of content that is contained in the subtitle.
+     * Each element in the list could be a string, formatted text, or a footnote reference.
+     */
+    content: (string | FormattedText | VerseFootnoteReference)[];
+}
+
+/**
+ * A verse in a chapter.
+ */
+export interface ChapterVerse {
+    /**
+     * Indicates that the content is a verse.
+     */
+    type: 'verse';
+
+    /**
+     * The number of the verse.
+     */
+    number: number;
+
+    /**
+     * The list of content for the verse.
+     * Each element in the list could be a string, formatted text, or a footnote reference.
+     */
+    content: (
+        | string
+        | FormattedText
+        | InlineHeading
+        | InlineLineBreak
+        | VerseFootnoteReference
+    )[];
+}
+
+/**
+ * Formatted text. That is, text that is formated in a particular manner.
+ */
+export interface FormattedText {
+    /**
+     * The text that is formatted.
+     */
+    text: string;
+
+    /**
+     * Whether the text represents a poem.
+     * The number indicates the level of indent.
+     *
+     * Common in Psalms.
+     */
+    poem?: number;
+
+    /**
+     * Whether the text represents the Words of Jesus.
+     */
+    wordsOfJesus?: boolean;
+}
+
+/**
+ * Defines an interface that represents a heading that is embedded in a verse.
+ */
+export interface InlineHeading {
+    /**
+     * The text of the heading.
+     */
+    heading: string;
+}
+
+/**
+ * Defines an interface that represents a line break that is embedded in a verse.
+ */
+export interface InlineLineBreak {
+    lineBreak: true;
+}
+
+/**
+ * A footnote reference in a verse or a Hebrew Subtitle.
+ */
+export interface VerseFootnoteReference {
+    /**
+     * The ID of the note.
+     */
+    noteId: number;
+}
+
+/**
+ * Information about a footnote.
+ */
+export interface ChapterFootnote {
+    /**
+     * The ID of the note that is referenced.
+     */
+    noteId: number;
+
+    /**
+     * The text of the footnote.
+     */
+    text: string;
+
+    /**
+     * The verse reference for the footnote.
+     */
+    reference?: {
+        chapter: number;
+        verse: number;
+    };
+
+    /**
+     * The caller that should be used for the footnote.
+     * For footnotes, a "caller" is the character that is used in the text to reference to footnote.
+     *
+     * For example, in the text:
+     * Hello (a) World
+     *
+     * ----
+     * (a) This is a footnote.
+     *
+     * The "(a)" is the caller.
+     *
+     * If "+", then the caller should be autogenerated.
+     * If null, then the caller should be empty.
+     * If a string, then the caller should be that string.
+     */
+    caller: '+' | string | null;
+}


### PR DESCRIPTION
Fixes #23

Full codegen pipeline via Makefile:

```
make fetch-upstream  # pin upstream TS types by commit SHA
make spec            # TS types → OpenAPI 3.1.0 (YAML + JSON)
make client          # OpenAPI JSON → typed Python client
make all             # both
```

**Upstream pinned to:** HelloAOLab/bible-api @ `1744dd3` (API v1.11.0)

**Generated client** (`scripts/generated_client/`):
- `BibleAPIClient` class with methods for all endpoints
- Typed dataclasses for response schemas
- stdlib only (urllib.request) — no pip deps
- Methods: `list_translations()`, `get_chapter()`, `get_commentary_chapter()`, `get_dataset_chapter()`, etc.

**Tested:** All 4 endpoint types working — 1256 translations, chapter content, commentary, cross-references.

When HelloAOLab updates their API, update `UPSTREAM_COMMIT` in the Makefile and run `make all` to regenerate everything.